### PR TITLE
docs: add label for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.md
+++ b/.github/ISSUE_TEMPLATE/00-bug.md
@@ -2,6 +2,7 @@
 name: Bugs
 about: config, server, client, or anything else
 title: "affected/package: "
+labels: bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/01-feature.md
+++ b/.github/ISSUE_TEMPLATE/01-feature.md
@@ -2,6 +2,7 @@
 name: Features
 about: config, server, client, or anything else
 title: "affected/package: "
+labels: enhancement
 ---
 
 <!--


### PR DESCRIPTION
1. 为issue模版添加label字段,使其自动标记为对应的label,方便issue过滤
2. 缺少`Proposal` label需要拥有权限的同学添加一下, proposal模版中用到了该label
3. 是否需要添加一个与`question`label对应的issue template?