### PR TITLE
docs: fix label name in 03-proposal.md and add question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-question.md
+++ b/.github/ISSUE_TEMPLATE/02-question.md
@@ -1,0 +1,27 @@
+---
+name: Questions
+about: questions or inquiries about the project
+title: "question: affected/package: "
+labels: question
+---
+
+### Preliminary Research
+
+<!--
+Please confirm the following before submitting your issue. Thanks!
+-->
+
+- [ ] I have read the project's documentation.
+- [ ] I have searched [existing issues](https://github.com/trpc-group/tnet/issues) for similar questions to see if my question has already been addressed.
+
+### Question
+
+<!--
+Ask your question or describe the issue you're facing. Be as clear and concise as possible.
+-->
+
+### Additional Information
+
+<!--
+If applicable, provide any additional information that may help clarify your question or inquiry.
+-->

--- a/.github/ISSUE_TEMPLATE/03-proposal.md
+++ b/.github/ISSUE_TEMPLATE/03-proposal.md
@@ -2,7 +2,7 @@
 name: Proposals
 about: New external API or other notable changes
 title: "proposal: affected/package: "
-labels: Proposal
+labels: proposal
 ---
 
 <!--


### PR DESCRIPTION
1. 新增question issue模版,自动打标签为question
2. 修改proposal issue模版中标签名使其与github上创建的标签相同