### PR TITLE
refactor: replace all interface{} with any in go1.18

### DIFF
--- a/extensions/websocket/conn.go
+++ b/extensions/websocket/conn.go
@@ -38,7 +38,7 @@ type conn struct {
 	// Note: This lock does not guarantee concurrent safety when reading message.
 	mu          sync.Mutex
 	raw         rawConnection
-	metaData    interface{}
+	metaData    any
 	role        ws.State    // ws.StateServerSide or ws.StateClientSide.
 	reader      io.Reader   // connection-wise message type reader for Read.
 	messageType MessageType // connection-wise message type for Read/Write.
@@ -56,9 +56,9 @@ type rawConnection interface {
 	// SetIdleTimeout sets the idle timeout to close connection.
 	SetIdleTimeout(d time.Duration) error
 	// SetMetaData sets meta data. Through this method, users can bind some custom data to a connection.
-	SetMetaData(interface{})
+	SetMetaData(any)
 	// GetMetaData gets meta data.
-	GetMetaData() interface{}
+	GetMetaData() any
 }
 
 // rawConn wraps tls.Conn to provide a pseudo Writev implementation.
@@ -296,12 +296,12 @@ func (w *writeCloser) Close() error {
 }
 
 // SetMetaData sets meta data.
-func (c *conn) SetMetaData(m interface{}) {
+func (c *conn) SetMetaData(m any) {
 	c.metaData = m
 }
 
 // GetMetaData gets meta data.
-func (c *conn) GetMetaData() interface{} {
+func (c *conn) GetMetaData() any {
 	return c.metaData
 }
 

--- a/extensions/websocket/websocket.go
+++ b/extensions/websocket/websocket.go
@@ -65,9 +65,9 @@ type Conn interface {
 	// A finished message write should end with writer.Close().
 	NextMessageWriter(MessageType) (io.WriteCloser, error)
 	// SetMetaData sets metadata. Through this method, users can bind some custom data to a connection.
-	SetMetaData(interface{})
+	SetMetaData(any)
 	// GetMetaData gets meta data.
-	GetMetaData() interface{}
+	GetMetaData() any
 	// Subprotocol returns the negotiated protocol for the connection.
 	Subprotocol() string
 	// SetPingHandler sets customized Ping frame handler.

--- a/internal/asynctimer/asynctimer.go
+++ b/internal/asynctimer/asynctimer.go
@@ -65,11 +65,11 @@ func Stop() {
 }
 
 // Callback is asynchronous callback function when timer expired.
-type Callback func(data interface{})
+type Callback func(data any)
 
 // Timer is an async timer.
 type Timer struct {
-	data          interface{}
+	data          any
 	expiredHandle Callback
 	begin         atomic.Time
 	circle        int
@@ -81,7 +81,7 @@ type Timer struct {
 // NewTimer creates an async timer with data and expiredHandle function. After timeout
 // time, the timer will be expired, and expiredHandle will be called with argument data.
 // Note that the timer becomes effective after having been added to time wheel.
-func NewTimer(data interface{}, expiredHandle Callback, timeout time.Duration) *Timer {
+func NewTimer(data any, expiredHandle Callback, timeout time.Duration) *Timer {
 	t := &Timer{
 		data:          data,
 		expiredHandle: expiredHandle,

--- a/internal/asynctimer/asynctimer_test.go
+++ b/internal/asynctimer/asynctimer_test.go
@@ -27,7 +27,7 @@ type testWrapper struct {
 	isHandled bool
 }
 
-var expireHandle = func(data interface{}) {
+var expireHandle = func(data any) {
 	t, ok := data.(*testWrapper)
 	if !ok {
 		return

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -57,7 +57,7 @@ var (
 )
 
 var bufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Buffer{}
 	},
 }

--- a/internal/buffer/node.go
+++ b/internal/buffer/node.go
@@ -20,7 +20,7 @@ import (
 )
 
 var nodePool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &node{}
 	},
 }

--- a/internal/cache/mcache/mcache.go
+++ b/internal/cache/mcache/mcache.go
@@ -28,7 +28,7 @@ var caches [maxSize]sync.Pool
 func init() {
 	for i := 0; i < maxSize; i++ {
 		size := 1 << i
-		caches[i].New = func() interface{} {
+		caches[i].New = func() any {
 			s := make([]byte, 0, size)
 			return s
 		}

--- a/internal/cache/systype/systype.go
+++ b/internal/cache/systype/systype.go
@@ -33,7 +33,7 @@ type IOVECWrapper struct {
 }
 
 var iovecPool sync.Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &IOVECWrapper{
 			iovec: make([]unix.Iovec, 0, MaxLen),
 		}
@@ -81,7 +81,7 @@ type IOData struct {
 }
 
 var ioDataPool sync.Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &IOData{
 			D: make([][]byte, 0, MaxLen),
 		}
@@ -122,7 +122,7 @@ var (
 )
 
 func init() {
-	mmsghdrsPool.New = func() interface{} {
+	mmsghdrsPool.New = func() any {
 		mmsghdrs := make([]MMsghdr, MaxLen)
 		return mmsghdrs
 	}

--- a/internal/netutil/fd.go
+++ b/internal/netutil/fd.go
@@ -27,7 +27,7 @@ import (
 )
 
 // GetFD returns the integer Unix file descriptor referencing the tcp/udp socket.
-func GetFD(socket interface{}) (int, error) {
+func GetFD(socket any) (int, error) {
 	conn, ok := socket.(syscall.Conn)
 	if !ok {
 		return -1, fmt.Errorf("type %T doesn't implement syscall.Conn interface", socket)
@@ -49,7 +49,7 @@ func GetFD(socket interface{}) (int, error) {
 }
 
 // DupFD duplicates file descriptor and returns the new fd.
-func DupFD(socket interface{}) (int, error) {
+func DupFD(socket any) (int, error) {
 	var f *os.File
 	var err error
 	switch conn := socket.(type) {

--- a/internal/poller/desc.go
+++ b/internal/poller/desc.go
@@ -37,12 +37,12 @@ type Desc struct {
 	next   *Desc
 	poller Poller
 	index  int32
-	Data   interface{}
+	Data   any
 
 	// Desc provides three callbacks for fd's reading, writing or hanging events.
-	OnRead  func(data interface{}, ioData *iovec.IOData) error
-	OnWrite func(data interface{}) error
-	OnHup   func(data interface{})
+	OnRead  func(data any, ioData *iovec.IOData) error
+	OnWrite func(data any) error
+	OnHup   func(data any)
 
 	// FD is the file descriptor that will be monitored by poller.
 	FD int

--- a/internal/poller/poller_epoll_test.go
+++ b/internal/poller/poller_epoll_test.go
@@ -54,7 +54,7 @@ func TestNormal(t *testing.T) {
 	pollDesc.FD = eventFD
 	pollDesc.Data = 1
 	ch := make(chan struct{}, 1)
-	pollDesc.OnRead = func(_ interface{}, _ *iovec.IOData) error {
+	pollDesc.OnRead = func(_ any, _ *iovec.IOData) error {
 		onRead++
 		ch <- struct{}{}
 		buf := make([]byte, 8)
@@ -62,7 +62,7 @@ func TestNormal(t *testing.T) {
 		return nil
 	}
 	hup := make(chan struct{}, 1)
-	pollDesc.OnHup = func(_ interface{}) {
+	pollDesc.OnHup = func(_ any) {
 		onHup = 1
 		hup <- struct{}{}
 	}
@@ -75,7 +75,7 @@ func TestNormal(t *testing.T) {
 	assert.Equal(t, n, len(buf))
 	<-ch
 	assert.Equal(t, onRead, 1)
-	pollDesc.OnRead = func(_ interface{}, _ *iovec.IOData) error {
+	pollDesc.OnRead = func(_ any, _ *iovec.IOData) error {
 		return errors.New("fake fails")
 	}
 	_, err = unix.Write(eventFD, buf)

--- a/internal/poller/poller_kqueue_test.go
+++ b/internal/poller/poller_kqueue_test.go
@@ -36,7 +36,7 @@ func TestNormal(t *testing.T) {
 	pollDesc.FD = readStream
 	pollDesc.Data = 0
 	var onRead, onWrite int
-	pollDesc.OnRead = func(interface{}, *iovec.IOData) error {
+	pollDesc.OnRead = func(any, *iovec.IOData) error {
 		onRead++
 		buf := make([]byte, 16)
 		n, err := unix.Read(pollDesc.FD, buf)
@@ -44,7 +44,7 @@ func TestNormal(t *testing.T) {
 		assert.Equal(t, 10, n)
 		return nil
 	}
-	pollDesc.OnWrite = func(interface{}) error {
+	pollDesc.OnWrite = func(any) error {
 		onWrite++
 		return nil
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -39,73 +39,73 @@ var encoderConfig = zapcore.EncoderConfig{
 // Logger provides a unified logging interface.
 type Logger interface {
 	// Debug logs to DEBUG log. Arguments are handled in the manner of fmt.Print.
-	Debug(args ...interface{})
+	Debug(args ...any)
 	// Debugf logs to DEBUG log. Arguments are handled in the manner of fmt.Printf.
-	Debugf(format string, args ...interface{})
+	Debugf(format string, args ...any)
 	// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
-	Info(args ...interface{})
+	Info(args ...any)
 	// Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
-	Infof(format string, args ...interface{})
+	Infof(format string, args ...any)
 	// Warn logs to WARNING log. Arguments are handled in the manner of fmt.Print.
-	Warn(args ...interface{})
+	Warn(args ...any)
 	// Warnf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
-	Warnf(format string, args ...interface{})
+	Warnf(format string, args ...any)
 	// Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	Error(args ...interface{})
+	Error(args ...any)
 	// Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 	// Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 }
 
 // Debug logs to DEBUG log. Arguments are handled in the manner of fmt.Print.
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Default.Debug(args...)
 }
 
 // Debugf logs to DEBUG log. Arguments are handled in the manner of fmt.Printf.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	Default.Debugf(format, args...)
 }
 
 // Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Default.Info(args...)
 }
 
 // Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Default.Infof(format, args...)
 }
 
 // Warn logs to WARNING log. Arguments are handled in the manner of fmt.Print.
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	Default.Warn(args...)
 }
 
 // Warnf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Default.Warnf(format, args...)
 }
 
 // Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Default.Error(args...)
 }
 
 // Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	Default.Errorf(format, args...)
 }
 
 // Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	Default.Fatal(args...)
 }
 
 // Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Default.Fatalf(format, args...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -22,13 +22,13 @@ func TestLog(t *testing.T) {
 
 type noopLogger struct{}
 
-func (*noopLogger) Debug(args ...interface{})                 {}
-func (*noopLogger) Debugf(format string, args ...interface{}) {}
-func (*noopLogger) Info(args ...interface{})                  {}
-func (*noopLogger) Infof(format string, args ...interface{})  {}
-func (*noopLogger) Warn(args ...interface{})                  {}
-func (*noopLogger) Warnf(format string, args ...interface{})  {}
-func (*noopLogger) Error(args ...interface{})                 {}
-func (*noopLogger) Errorf(format string, args ...interface{}) {}
-func (*noopLogger) Fatal(args ...interface{})                 {}
-func (*noopLogger) Fatalf(format string, args ...interface{}) {}
+func (*noopLogger) Debug(args ...any)                 {}
+func (*noopLogger) Debugf(format string, args ...any) {}
+func (*noopLogger) Info(args ...any)                  {}
+func (*noopLogger) Infof(format string, args ...any)  {}
+func (*noopLogger) Warn(args ...any)                  {}
+func (*noopLogger) Warnf(format string, args ...any)  {}
+func (*noopLogger) Error(args ...any)                 {}
+func (*noopLogger) Errorf(format string, args ...any) {}
+func (*noopLogger) Fatal(args ...any)                 {}
+func (*noopLogger) Fatalf(format string, args ...any) {}

--- a/netfd.go
+++ b/netfd.go
@@ -121,10 +121,10 @@ func (nfd *netFD) close() {
 
 // Schedule add NetFD to poller system, and monitor Readable Event.
 func (nfd *netFD) Schedule(
-	onRead func(data interface{}, ioData *iovec.IOData) error,
-	onWrite func(data interface{}) error,
-	onHup func(data interface{}),
-	conn interface{},
+	onRead func(data any, ioData *iovec.IOData) error,
+	onWrite func(data any) error,
+	onHup func(data any),
+	conn any,
 ) error {
 	if nfd.desc != nil {
 		return errors.New("already in poller system")

--- a/taskpool.go
+++ b/taskpool.go
@@ -24,7 +24,7 @@ var (
 	usrPool, _  = ants.NewPool(maxRoutines)
 )
 
-func taskHandler(v interface{}) {
+func taskHandler(v any) {
 	switch conn := v.(type) {
 	case *tcpconn:
 		tcpAsyncHandler(conn)
@@ -33,7 +33,7 @@ func taskHandler(v interface{}) {
 	}
 }
 
-func doTask(args interface{}) error {
+func doTask(args any) error {
 	metrics.Add(metrics.TaskAssigned, 1)
 	return sysPool.Invoke(args)
 }

--- a/tcpconn.go
+++ b/tcpconn.go
@@ -57,7 +57,7 @@ var _ Conn = (*tcpconn)(nil)
 
 type tcpconn struct {
 	service     *tcpservice
-	metaData    interface{}
+	metaData    any
 	reqHandle   atomic.Value
 	closeHandle atomic.Value
 	readTrigger chan struct{}
@@ -573,7 +573,7 @@ func (tc *tcpconn) refreshConn() error {
 	return nil
 }
 
-func tcpOnIdle(data interface{}) {
+func tcpOnIdle(data any) {
 	c, ok := data.(Conn)
 	if !ok {
 		return
@@ -581,7 +581,7 @@ func tcpOnIdle(data interface{}) {
 	c.Close()
 }
 
-func tcpOnRead(data interface{}, ioData *iovec.IOData) error {
+func tcpOnRead(data any, ioData *iovec.IOData) error {
 	// data passed from desc to tcpOnRead must be of type *tcpconn.
 	tc, ok := data.(*tcpconn)
 	if !ok || tc == nil {
@@ -621,7 +621,7 @@ func tcpOnRead(data interface{}, ioData *iovec.IOData) error {
 	return doTask(tc)
 }
 
-func tcpOnWrite(data interface{}) error {
+func tcpOnWrite(data any) error {
 	// data passed from desc to tcpOnWrite must be of type *tcpconn.
 	tc, ok := data.(*tcpconn)
 	if !ok || tc == nil {
@@ -658,7 +658,7 @@ func tcpOnWrite(data interface{}) error {
 	return nil
 }
 
-func tcpOnHup(data interface{}) {
+func tcpOnHup(data any) {
 	tc, ok := data.(*tcpconn)
 	if ok && tc != nil {
 		tc.Close()
@@ -711,11 +711,11 @@ func tcpSyncHandle(conn *tcpconn) error {
 }
 
 // SetMetaData sets meta data.
-func (tc *tcpconn) SetMetaData(m interface{}) {
+func (tc *tcpconn) SetMetaData(m any) {
 	tc.metaData = m
 }
 
 // GetMetaData gets meta data.
-func (tc *tcpconn) GetMetaData() interface{} {
+func (tc *tcpconn) GetMetaData() any {
 	return tc.metaData
 }

--- a/tcpservice.go
+++ b/tcpservice.go
@@ -111,7 +111,7 @@ func (s *tcpservice) close() error {
 
 // tcpServiceOnRead is triggered by the tcp listener read event,
 // which means that "accept" needs to be handled.
-func tcpServiceOnRead(data interface{}, _ *iovec.IOData) error {
+func tcpServiceOnRead(data any, _ *iovec.IOData) error {
 	s, ok := data.(*tcpservice)
 	if !ok || s == nil {
 		panic(fmt.Sprintf("bug: data is not *tcpservice type (%v) or s is nil pointer (%v)", !ok, s == nil))
@@ -155,7 +155,7 @@ func tcpServiceOnRead(data interface{}, _ *iovec.IOData) error {
 	return nil
 }
 
-func tcpServiceOnHup(data interface{}) {
+func tcpServiceOnHup(data any) {
 	s, ok := data.(*tcpservice)
 	if !ok || s == nil {
 		panic(fmt.Sprintf("bug: data is not *tcpservice type (%v) or s is nil pointer (%v)", !ok, s == nil))

--- a/tls/conn.go
+++ b/tls/conn.go
@@ -24,16 +24,16 @@ import (
 type conn struct {
 	*tls.Conn
 	raw      tnet.Conn
-	metaData interface{}
+	metaData any
 }
 
 // SetMetaData sets meta data.
-func (c *conn) SetMetaData(m interface{}) {
+func (c *conn) SetMetaData(m any) {
 	c.metaData = m
 }
 
 // GetMetaData gets meta data.
-func (c *conn) GetMetaData() interface{} {
+func (c *conn) GetMetaData() any {
 	return c.metaData
 }
 

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -23,9 +23,9 @@ import (
 type Conn interface {
 	net.Conn
 	// SetMetaData sets meta data. Through this method, users can bind some custom data to a connection.
-	SetMetaData(interface{})
+	SetMetaData(any)
 	// GetMetaData gets meta data.
-	GetMetaData() interface{}
+	GetMetaData() any
 	// SetIdleTimeout sets connection level idle timeout.
 	SetIdleTimeout(d time.Duration) error
 	// SetFlushWrite sets flush write flag for the connection.

--- a/tnet.go
+++ b/tnet.go
@@ -42,10 +42,10 @@ type BaseConn interface {
 	SetFlushWrite(flushWrite bool)
 
 	// SetMetaData sets metadata. Through this method, users can bind some custom data to a connection.
-	SetMetaData(m interface{})
+	SetMetaData(m any)
 
 	// GetMetaData gets metadata.
-	GetMetaData() interface{}
+	GetMetaData() any
 }
 
 // Conn is generic for stream oriented network connection.

--- a/udpconn.go
+++ b/udpconn.go
@@ -36,7 +36,7 @@ import (
 var _ PacketConn = (*udpconn)(nil)
 
 type udpconn struct {
-	metaData    interface{}
+	metaData    any
 	reqHandle   atomic.Value
 	closeHandle atomic.Value
 	readTrigger chan struct{}
@@ -416,7 +416,7 @@ func (uc *udpconn) getOnRequest() UDPHandler {
 	return reqHandle
 }
 
-func udpOnRead(data interface{}, _ *iovec.IOData) error {
+func udpOnRead(data any, _ *iovec.IOData) error {
 	// data passed from desc to udpOnRead must be of type *udpconn.
 	uc, ok := data.(*udpconn)
 	if !ok || uc == nil {
@@ -451,7 +451,7 @@ func udpOnRead(data interface{}, _ *iovec.IOData) error {
 	return doTask(uc)
 }
 
-func udpOnWrite(data interface{}) error {
+func udpOnWrite(data any) error {
 	// data passed from desc to udpOnWrite must be of type *udpconn.
 	uc, ok := data.(*udpconn)
 	if !ok || uc == nil {
@@ -570,11 +570,11 @@ func udpSyncHandle(conn *udpconn) error {
 }
 
 // SetMetaData sets meta data.
-func (uc *udpconn) SetMetaData(m interface{}) {
+func (uc *udpconn) SetMetaData(m any) {
 	uc.metaData = m
 }
 
 // GetMetaData gets meta data.
-func (uc *udpconn) GetMetaData() interface{} {
+func (uc *udpconn) GetMetaData() any {
 	return uc.metaData
 }


### PR DESCRIPTION
1. go.mod中约定的go最小版本为`1.18`
2. 在go 1.18中可以使用any替代interface{}, https://pkg.go.dev/builtin#any
3. 在根目录下使用`gofmt -w -r 'interface{} -> any' .`完成替换, 使用`find . -name "*.go"|xargs grep "interface{}"`检查替换结果