### PR TITLE
tcpconn: check negative idle timeout to prevent unexpected behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Change Log
+
+## v1.0.1 (2024-04-15)
+
+### Bug Fixes
+
+- tcpconn: check negative idle timeout to prevent unexpected behaviour (#17)

--- a/tcpconn.go
+++ b/tcpconn.go
@@ -502,7 +502,7 @@ func (tc *tcpconn) SetIdleTimeout(d time.Duration) error {
 	if !tc.IsActive() {
 		return ErrConnClosed
 	}
-	if d == 0 {
+	if d <= 0 {
 		return nil
 	}
 	if tc.idleTimer != nil {


### PR DESCRIPTION
Fix https://github.com/trpc-group/trpc-go/issues/165#issuecomment-2054508890.