### PR TITLE
tnet: sync tcp and buffer fixes

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -14,6 +14,7 @@
 package tnet
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -28,13 +29,28 @@ import (
 // DialTCP connects to the address on the named network within the timeout.
 // Valid networks for DialTCP are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only).
 func DialTCP(network, address string, timeout time.Duration) (Conn, error) {
+	return dialTCP(context.Background(), network, address, timeout)
+}
+
+// DialContextTCP connects to the address on the named network using the provided context.
+// Valid networks for DialTCP are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only).
+func DialContextTCP(ctx context.Context, network, address string) (Conn, error) {
+	return dialTCP(ctx, network, address, 0)
+}
+
+func dialTCP(ctx context.Context, network, address string, timeout time.Duration) (Conn, error) {
 	reportDialTCP()
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 	default:
 		return nil, fmt.Errorf("DialTCP: unknown network %s", network)
 	}
-	return dialTCP(network, address, timeout)
+	d := net.Dialer{Timeout: timeout}
+	c, err := d.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, fmt.Errorf("dial network %s, address %s with timeout %+v error: %w", network, address, timeout, err)
+	}
+	return newTCPConn(c, network)
 }
 
 // DialUDP connects to the address on the named network within the timeout.
@@ -49,11 +65,7 @@ func DialUDP(network, address string, timeout time.Duration) (PacketConn, error)
 	return dialUDP(network, address, timeout)
 }
 
-func dialTCP(network, address string, timeout time.Duration) (Conn, error) {
-	c, err := net.DialTimeout(network, address, timeout)
-	if err != nil {
-		return nil, fmt.Errorf("dial network %s, address %s with timeout %+v error: %w", network, address, timeout, err)
-	}
+func newTCPConn(c net.Conn, network string) (Conn, error) {
 	fd, err := netutil.GetFD(c)
 	if err != nil {
 		c.Close()
@@ -68,12 +80,13 @@ func dialTCP(network, address string, timeout time.Duration) (Conn, error) {
 			raddr:   c.RemoteAddr(),
 			network: network,
 		},
-		readTrigger: make(chan struct{}, 1),
-		writevData:  iovec.NewIOData(),
+		readTrigger:    make(chan struct{}, 1),
+		closedFinished: make(chan struct{}, 1),
+		writevData:     iovec.NewIOData(),
 	}
 	conn.inBuffer.Initialize()
 	conn.outBuffer.Initialize()
-	conn.closedReadBuf.Initialize(nil)
+	conn.closedReadBuf.Initialize(nil, ErrConnClosed)
 	if err := conn.nfd.Schedule(tcpOnRead, tcpOnWrite, tcpOnHup, conn); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("dial tcp net fd schedule error: %w", err)

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -311,4 +312,115 @@ func TestDialUDP_Tnet_Async(t *testing.T) {
 		time.Sleep(time.Microsecond)
 	}
 	wg.Wait()
+}
+
+// TestDialContextTCP_Success tests successful connection using DialContextTCP
+func TestDialContextTCP_Success(t *testing.T) {
+	// Start a TCP server
+	waitCh := make(chan string)
+	addr := getTestAddr()
+	go startNetTCPServer(t, "tcp", addr, waitCh)
+	serverAddr := <-waitCh
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Connect to the server using DialContextTCP
+	conn, err := tnet.DialContextTCP(ctx, "tcp", serverAddr)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	// Verify connection by sending and receiving data
+	_, err = conn.Write(helloWorld)
+	require.Nil(t, err)
+	rsp, err := conn.ReadN(len(helloWorld))
+	require.Nil(t, err)
+	assert.Equal(t, helloWorld, rsp)
+}
+
+// TestDialContextTCP_CancelledContext tests connection attempt with a cancelled context
+func TestDialContextTCP_CancelledContext(t *testing.T) {
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Attempt to connect with cancelled context
+	addr := getTestAddr()
+	_, err := tnet.DialContextTCP(ctx, "tcp", addr)
+	require.NotNil(t, err)
+	// The error message might vary, but it should indicate the operation was canceled
+	assert.Contains(t, err.Error(), "canceled")
+}
+
+// TestDialContextTCP_Timeout tests connection attempt with a context that times out
+func TestDialContextTCP_Timeout(t *testing.T) {
+	// Create a TCP listener but don't accept any connections
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+
+	// Create a context with a very short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+
+	// Wait a bit to ensure the context has expired
+	time.Sleep(time.Millisecond)
+
+	// Attempt to connect with an expired context
+	_, err = tnet.DialContextTCP(ctx, "tcp", ln.Addr().String())
+	require.NotNil(t, err)
+	// The error message might vary, but it should indicate a timeout or deadline exceeded
+	assert.True(t,
+		containsAny(err.Error(), []string{"timeout", "deadline exceeded", "i/o timeout", "operation was canceled"}),
+		"Error message should indicate timeout: %s", err.Error())
+}
+
+// TestDialContextTCP_InvalidNetwork tests connection attempt with an invalid network
+func TestDialContextTCP_InvalidNetwork(t *testing.T) {
+	ctx := context.Background()
+	addr := getTestAddr()
+	_, err := tnet.DialContextTCP(ctx, "unix", addr)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unknown network")
+}
+
+// TestDialContextTCP_WithTnetServer tests connection to a tnet TCP server
+func TestDialContextTCP_WithTnetServer(t *testing.T) {
+	// Start a tnet TCP server
+	waitCh := make(chan string)
+	addr := getTestAddr()
+	go startTnetTCPServer(t, "tcp", addr, waitCh)
+	serverAddr := <-waitCh
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Connect to the server using DialContextTCP
+	conn, err := tnet.DialContextTCP(ctx, "tcp", serverAddr)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	// Verify connection by sending and receiving data
+	_, err = conn.Write(helloWorld)
+	require.Nil(t, err)
+	rsp, err := conn.ReadN(len(helloWorld))
+	require.Nil(t, err)
+	assert.Equal(t, helloWorld, rsp)
+}
+
+// containsAny checks if the string contains any of the substrings
+func containsAny(s string, substrings []string) bool {
+	for _, substr := range substrings {
+		if contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// contains is a helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(substr) > 0 && len(s) >= len(substr) && strings.Contains(s, substr)
 }

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -679,8 +679,8 @@ func (b *Buffer) Release() {
 	}
 	// Update NodeBlockSize as the maximum readLength
 	// to minimize node allocation.
-	if b.enableAutoNodeBlockSize {
-		for b.nodeBlockSize < uint32(readLength) && b.nodeBlockSize*2 <= maxNodeBlockSize {
+	if b.enableAutoNodeBlockSize && readLength <= maxNodeBlockSize {
+		for int64(b.nodeBlockSize) < int64(readLength) && b.nodeBlockSize*2 <= maxNodeBlockSize {
 			b.nodeBlockSize <<= 1
 		}
 	}

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -64,6 +64,12 @@ var bufferPool = sync.Pool{
 
 // Buffer implements buffer chains to store data, it's safe to access data concurrently.
 // The internal locker can make sure that only one reader and writer will be accessing data at any time.
+/*
+  Buffer data structure diagram:
+  head          rnode         wnode         tail
+   ↓             ↓             ↓             ↓
+  node → node → node → node → node → node → node
+*/
 type Buffer struct {
 	head  *node
 	tail  *node
@@ -75,7 +81,11 @@ type Buffer struct {
 	// wlock can make sure only one writer to modify wlen.
 	wlock sync.Mutex
 
+	// rlen denotes the number of bytes that can be read from the buffer.
+	// It increases when data is written and decreases when data is read.
 	rlen atomic.Uint32
+	// wlen denotes the number of bytes that can be written to the buffer.
+	// It increases when new nodes are added and decreases when data is written.
 	wlen atomic.Uint32
 
 	// nodeBlockSize denotes the size of the block when adding
@@ -139,6 +149,9 @@ func SetCleanUp(b bool) {
 func (b *Buffer) Peek(n int) ([]byte, error) {
 	if n < 0 {
 		return nil, ErrInvalidParam
+	}
+	if n == 0 {
+		return []byte{}, nil
 	}
 	b.rlock.Lock()
 	defer b.rlock.Unlock()
@@ -224,6 +237,9 @@ func (b *Buffer) Skip(n int) error {
 func (b *Buffer) Next(n int) ([]byte, error) {
 	if n < 0 {
 		return nil, ErrInvalidParam
+	}
+	if n == 0 {
+		return []byte{}, nil
 	}
 	b.rlock.Lock()
 	defer b.rlock.Unlock()
@@ -329,14 +345,15 @@ func (b *Buffer) PeekBlocks(data [][]byte) int {
 	var blocks int
 	for rest, rnode := b.LenRead(), b.rnode; blocks < len(data) && rest > 0; rnode = rnode.next {
 		l := rnode.len()
-		if l != 0 {
-			if l > rest {
-				l = rest
-			}
-			data[blocks] = rnode.block[rnode.r : int(rnode.r)+l]
-			rest -= l
-			blocks++
+		if l == 0 {
+			continue
 		}
+		if l > rest {
+			l = rest
+		}
+		data[blocks] = rnode.block[rnode.r : int(rnode.r)+l]
+		rest -= l
+		blocks++
 	}
 	return blocks
 }
@@ -662,8 +679,8 @@ func (b *Buffer) Release() {
 	}
 	// Update NodeBlockSize as the maximum readLength
 	// to minimize node allocation.
-	if b.enableAutoNodeBlockSize && uint32(readLength) > b.nodeBlockSize && readLength < maxNodeBlockSize {
-		for b.nodeBlockSize < uint32(readLength) {
+	if b.enableAutoNodeBlockSize {
+		for b.nodeBlockSize < uint32(readLength) && b.nodeBlockSize*2 <= maxNodeBlockSize {
 			b.nodeBlockSize <<= 1
 		}
 	}

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -101,6 +101,7 @@ func TestBuffer_Write(t *testing.T) {
 func TestBuffer_Peek(t *testing.T) {
 	b := New()
 	defer Free(b)
+
 	s1, s2 := []byte{1, 2, 3}, []byte{4, 5, 6}
 	b.Writev(false, s1, s2)
 
@@ -123,6 +124,33 @@ func TestBuffer_Peek(t *testing.T) {
 
 	_, err = b.Peek(7)
 	assert.Equal(t, err, ErrNoEnoughData)
+
+	err = b.Skip(len(s1) + len(s2))
+	assert.Nil(t, err)
+	chain := &chain{}
+	chain.initialize(false, []byte{1, 2, 3})
+	b.addChain(chain)
+	b.PeekBlocks([][]byte{nil})
+}
+
+func TestBuffer_Peek_zero(t *testing.T) {
+	b := New()
+	defer Free(b)
+
+	res, err := b.Peek(0)
+	assert.Nil(t, err)
+	assert.Len(t, res, 0)
+	assert.NotNil(t, b.head)
+	assert.Equal(t, b.head, b.rnode)
+
+	b.Writev(false, []byte{1, 2, 3})
+	res, err = b.Peek(0)
+	assert.Nil(t, err)
+	assert.Len(t, res, 0)
+
+	res, err = b.Peek(3)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3}, res)
 }
 
 func TestBuffer_Peek_err(t *testing.T) {
@@ -189,6 +217,30 @@ func TestBuffer_Next(t *testing.T) {
 	res, err = b.Next(6)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{4, 5, 6, 7, 8, 9}, res)
+}
+
+func TestBuffer_Next_zero(t *testing.T) {
+	b := New()
+	defer Free(b)
+
+	res, err := b.Next(0)
+	assert.Nil(t, err)
+	assert.Len(t, res, 0)
+	assert.NotNil(t, b.head)
+	assert.Equal(t, b.head, b.rnode)
+
+	b.Writev(false, []byte{1, 2, 3})
+	assert.Equal(t, 3, b.LenRead())
+
+	res, err = b.Next(0)
+	assert.Nil(t, err)
+	assert.Len(t, res, 0)
+	assert.Equal(t, 3, b.LenRead())
+
+	res, err = b.Next(3)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3}, res)
+	assert.Zero(t, b.LenRead())
 }
 
 func TestBuffer_Next_err(t *testing.T) {

--- a/internal/buffer/fixed_buffer.go
+++ b/internal/buffer/fixed_buffer.go
@@ -15,7 +15,6 @@
 package buffer
 
 import (
-	"io"
 	"sync"
 
 	"go.uber.org/atomic"
@@ -24,19 +23,21 @@ import (
 // FixedReadBuffer is a fixed size buffer for reading.
 // It's concurrent safe in Read, Peek, Skip, Next, ReadN.
 type FixedReadBuffer struct {
-	buf  []byte
-	rlen atomic.Uint32
-	pos  atomic.Uint32
-	lock sync.Mutex
+	buf    []byte
+	rlen   atomic.Uint32
+	pos    atomic.Uint32
+	lock   sync.Mutex
+	eofErr error
 }
 
 // Initialize initializes the buffer with the given buffer.
-func (b *FixedReadBuffer) Initialize(buf []byte) {
+func (b *FixedReadBuffer) Initialize(buf []byte, eofErr error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	b.buf = buf
 	b.rlen.Store(uint32(len(buf)))
 	b.pos.Store(0)
+	b.eofErr = eofErr
 }
 
 // Read copies data from buffer and advances the pointer, it will release unused buffer automatically.
@@ -51,7 +52,7 @@ func (b *FixedReadBuffer) Read(p []byte) (int, error) {
 
 	rlen := b.LenRead()
 	if rlen == 0 {
-		return 0, io.EOF
+		return 0, b.eofErr
 	}
 
 	if rlen < n {
@@ -81,7 +82,7 @@ func (b *FixedReadBuffer) Peek(n int) ([]byte, error) {
 
 	rlen := b.LenRead()
 	if rlen < n {
-		return nil, io.EOF
+		return nil, b.eofErr
 	}
 
 	curPos := b.CurPos()
@@ -104,7 +105,7 @@ func (b *FixedReadBuffer) Skip(n int) error {
 
 	rlen := b.LenRead()
 	if rlen < n {
-		return io.EOF
+		return b.eofErr
 	}
 
 	b.pos.Add(uint32(n))
@@ -129,7 +130,7 @@ func (b *FixedReadBuffer) Next(n int) ([]byte, error) {
 
 	rlen := b.LenRead()
 	if rlen < n {
-		return nil, io.EOF
+		return nil, b.eofErr
 	}
 
 	curPos := b.CurPos()
@@ -152,7 +153,7 @@ func (b *FixedReadBuffer) ReadN(n int) ([]byte, error) {
 
 	rlen := b.LenRead()
 	if rlen < n {
-		return nil, io.EOF
+		return nil, b.eofErr
 	}
 
 	curPos := b.CurPos()

--- a/internal/buffer/fixed_buffer_test.go
+++ b/internal/buffer/fixed_buffer_test.go
@@ -15,9 +15,12 @@ package buffer
 
 import (
 	"bytes"
-	"io"
 	"testing"
+
+	"github.com/pkg/errors"
 )
+
+var testExpectedErr = errors.New("expected error")
 
 func TestFixedReadBuffer(t *testing.T) {
 	// Table-driven test cases
@@ -77,7 +80,7 @@ func TestFixedReadBuffer(t *testing.T) {
 			initData:    []byte{},
 			readSize:    1,
 			expected:    []byte{},
-			expectError: io.EOF,
+			expectError: testExpectedErr,
 		},
 		{
 			name:        "Read after all data consumed",
@@ -89,7 +92,7 @@ func TestFixedReadBuffer(t *testing.T) {
 				// Try to read again after all data consumed
 				data := make([]byte, 1)
 				n, err := buf.Read(data)
-				if n != 0 || err != io.EOF {
+				if n != 0 || err != testExpectedErr {
 					t.Errorf("Expected EOF after all data consumed, got: err=%v, n=%d", err, n)
 				}
 			},
@@ -100,7 +103,7 @@ func TestFixedReadBuffer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create and initialize buffer
 			buf := &FixedReadBuffer{}
-			buf.Initialize(tt.initData)
+			buf.Initialize(tt.initData, testExpectedErr)
 
 			// Read data
 			data := make([]byte, tt.readSize)
@@ -152,7 +155,7 @@ func TestFixedReadBuffer_Peek(t *testing.T) {
 			initData:    []byte("hello"),
 			peekSize:    10,
 			expected:    nil,
-			expectError: io.EOF,
+			expectError: testExpectedErr,
 			validate: func(t *testing.T, buf *FixedReadBuffer) {
 				// Ensure peek didn't change buffer state even on error
 				if buf.LenRead() != 5 {
@@ -191,7 +194,7 @@ func TestFixedReadBuffer_Peek(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &FixedReadBuffer{}
-			buf.Initialize(tt.initData)
+			buf.Initialize(tt.initData, testExpectedErr)
 
 			// Check initial length
 			initialLen := buf.LenRead()
@@ -249,7 +252,7 @@ func TestFixedReadBuffer_Skip(t *testing.T) {
 			name:        "Skip more data than available",
 			initData:    []byte("hello"),
 			skipSize:    10,
-			expectError: io.EOF,
+			expectError: testExpectedErr,
 		},
 		{
 			name:        "Skip with negative size",
@@ -274,7 +277,7 @@ func TestFixedReadBuffer_Skip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &FixedReadBuffer{}
-			buf.Initialize(tt.initData)
+			buf.Initialize(tt.initData, testExpectedErr)
 
 			err := buf.Skip(tt.skipSize)
 
@@ -322,7 +325,7 @@ func TestFixedReadBuffer_Next(t *testing.T) {
 			initData:    []byte("hello"),
 			nextSize:    10,
 			expected:    nil,
-			expectError: io.EOF,
+			expectError: testExpectedErr,
 		},
 		{
 			name:        "Next with negative size",
@@ -349,7 +352,7 @@ func TestFixedReadBuffer_Next(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &FixedReadBuffer{}
-			buf.Initialize(tt.initData)
+			buf.Initialize(tt.initData, testExpectedErr)
 
 			data, err := buf.Next(tt.nextSize)
 
@@ -401,7 +404,7 @@ func TestFixedReadBuffer_ReadN(t *testing.T) {
 			initData:    []byte("hello"),
 			readSize:    10,
 			expected:    nil,
-			expectError: io.EOF,
+			expectError: testExpectedErr,
 		},
 		{
 			name:        "ReadN with negative size",
@@ -428,7 +431,7 @@ func TestFixedReadBuffer_ReadN(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &FixedReadBuffer{}
-			buf.Initialize(tt.initData)
+			buf.Initialize(tt.initData, testExpectedErr)
 
 			data, err := buf.ReadN(tt.readSize)
 
@@ -451,7 +454,7 @@ func TestFixedReadBuffer_LenAndPos(t *testing.T) {
 	buf := &FixedReadBuffer{}
 	data := []byte("hello world")
 
-	buf.Initialize(data)
+	buf.Initialize(data, testExpectedErr)
 
 	// Test initial state
 	if buf.LenRead() != len(data) {
@@ -485,19 +488,19 @@ func TestFixedReadBuffer_LenAndPos(t *testing.T) {
 func TestFixedReadBuffer_EdgeCases(t *testing.T) {
 	t.Run("Zero size buffer", func(t *testing.T) {
 		buf := &FixedReadBuffer{}
-		buf.Initialize([]byte{})
+		buf.Initialize([]byte{}, testExpectedErr)
 
 		// Read should return EOF
 		data := make([]byte, 1)
 		n, err := buf.Read(data)
-		if n != 0 || err != io.EOF {
+		if n != 0 || err != testExpectedErr {
 			t.Errorf("Reading from empty buffer should return EOF")
 		}
 	})
 
 	t.Run("Concurrent read safety", func(t *testing.T) {
 		buf := &FixedReadBuffer{}
-		buf.Initialize(make([]byte, 100))
+		buf.Initialize(make([]byte, 100), testExpectedErr)
 		done := make(chan bool)
 
 		// Start multiple concurrent read goroutines
@@ -506,7 +509,7 @@ func TestFixedReadBuffer_EdgeCases(t *testing.T) {
 				data := make([]byte, 10)
 				for j := 0; j < 10; j++ {
 					_, err := buf.Read(data)
-					if err != nil && err != io.EOF {
+					if err != nil && err != testExpectedErr {
 						t.Errorf("Failed to read data: err=%v", err)
 					}
 				}
@@ -529,7 +532,7 @@ func TestFixedReadBuffer_EdgeCases(t *testing.T) {
 			largeData[i] = byte(i % chunkSize)
 		}
 
-		buf.Initialize(largeData)
+		buf.Initialize(largeData, testExpectedErr)
 
 		// Read in multiple chunks
 		for i := 0; i < chunkNum; i++ {

--- a/netfd.go
+++ b/netfd.go
@@ -213,7 +213,8 @@ func (nfd *netFD) WriteTo(data []byte, addr net.Addr) (int, error) {
 		return 0, errors.New("address can't be nil")
 	}
 	if len(data) > nfd.udpBufferSize {
-		return 0, fmt.Errorf("data length %d is too long, the max udp buffer size is %d", len(data), nfd.udpBufferSize)
+		return 0, fmt.Errorf("data length %d is too long, the max udp buffer size is %d: %w",
+			len(data), nfd.udpBufferSize, unix.EMSGSIZE)
 	}
 	sa, err := netutil.AddrToSockAddr(nfd.laddr, addr)
 	if err != nil {

--- a/netfd_test.go
+++ b/netfd_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 	"trpc.group/trpc-go/tnet/internal/netutil"
 )
 
@@ -124,4 +125,16 @@ func Test_netFD_WriteToIPv4(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(helloWorld), n)
 	<-wait
+}
+
+func Test_WriteTo_TooLong(t *testing.T) {
+	rawConn, err := rawListenUDP("udp4")
+	assert.Nil(t, err)
+	defer rawConn.Close()
+	nfd, err := rawToNetFD(rawConn)
+	assert.Nil(t, err)
+	addr := net.ParseIP("127.0.0.1")
+	_, err = nfd.WriteTo(make([]byte, defaultUDPBufferSize+1), &net.UDPAddr{IP: addr, Port: 0})
+	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, unix.EMSGSIZE)
 }

--- a/tcpconn.go
+++ b/tcpconn.go
@@ -61,6 +61,7 @@ type tcpconn struct {
 	reqHandle      atomic.Value
 	closeHandle    atomic.Value
 	readTrigger    chan struct{}
+	closedFinished chan struct{}
 	inBuffer       buffer.Buffer
 	outBuffer      buffer.Buffer
 	closedReadBuf  buffer.FixedReadBuffer
@@ -103,17 +104,27 @@ func checkAndSetBufferCleanUp() {
 }
 
 // Read reads data from the tcpconn.
-func (tc *tcpconn) Read(b []byte) (int, error) {
+func (tc *tcpconn) Read(b []byte) (n int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	if !tc.IsActive() {
-		return tc.closedReadBuf.Read(b)
-	}
-	if !tc.beginJobSafely(apiRead) {
+
+	isLocked := false
+	defer func() {
+		// release apiRead lock first to avoid deadlock with closedFinished
+		if isLocked {
+			tc.endJobSafely(apiRead)
+		}
+		// if conn is closed,  wait storeReadBuffer finished and read from closedReadBuf
+		if tc.needReadFromClosedReadBuf(err) {
+			tc.waitReadFromClosedReadBuf()
+			n, err = tc.closedReadBuf.Read(b)
+		}
+	}()
+
+	if isLocked = tc.beginJobSafely(apiRead); !isLocked {
 		return 0, ErrConnClosed
 	}
-	defer tc.endJobSafely(apiRead)
 
 	if err := tc.waitRead(1); err != nil {
 		return 0, err
@@ -122,20 +133,28 @@ func (tc *tcpconn) Read(b []byte) (int, error) {
 }
 
 // ReadN reads fixed length of data from the tcpconn.
-func (tc *tcpconn) ReadN(n int) ([]byte, error) {
-	if !tc.IsActive() {
-		return tc.closedReadBuf.ReadN(n)
-	}
-	if !tc.beginJobSafely(apiRead) {
+func (tc *tcpconn) ReadN(n int) (bytes []byte, err error) {
+	isLocked := false
+	defer func() {
+		// release apiRead lock to avoid deadlock with closedFinished
+		if isLocked {
+			tc.endJobSafely(apiRead)
+		}
+		// if conn is closed, lock closeProcess job to wait storeReadBuffer finished and read from closedReadBuf
+		if tc.needReadFromClosedReadBuf(err) {
+			tc.waitReadFromClosedReadBuf()
+			bytes, err = tc.closedReadBuf.ReadN(n)
+		}
+	}()
+	if isLocked = tc.beginJobSafely(apiRead); !isLocked {
 		return nil, ErrConnClosed
 	}
-	defer tc.endJobSafely(apiRead)
 
 	if err := tc.waitRead(n); err != nil {
 		return nil, err
 	}
 	dst := make([]byte, n)
-	_, err := tc.inBuffer.Read(dst)
+	_, err = tc.inBuffer.Read(dst)
 	if err != nil {
 		return nil, err
 	}
@@ -143,14 +162,23 @@ func (tc *tcpconn) ReadN(n int) ([]byte, error) {
 }
 
 // Next reads fixed length of data from the tcpconn.
-func (tc *tcpconn) Next(n int) ([]byte, error) {
-	if !tc.IsActive() {
-		return tc.closedReadBuf.Next(n)
-	}
-	if !tc.beginJobSafely(apiRead) {
+func (tc *tcpconn) Next(n int) (bytes []byte, err error) {
+	isLocked := false
+	defer func() {
+		// release apiRead lock to avoid deadlock with closedFinished
+		if isLocked {
+			tc.endJobSafely(apiRead)
+		}
+		// if conn is closed, lock closeProcess job to wait storeReadBuffer finished and read from closedReadBuf
+		if tc.needReadFromClosedReadBuf(err) {
+			tc.waitReadFromClosedReadBuf()
+			bytes, err = tc.closedReadBuf.Next(n)
+		}
+	}()
+
+	if isLocked = tc.beginJobSafely(apiRead); !isLocked {
 		return nil, ErrConnClosed
 	}
-	defer tc.endJobSafely(apiRead)
 
 	if err := tc.waitRead(n); err != nil {
 		return nil, err
@@ -161,14 +189,23 @@ func (tc *tcpconn) Next(n int) ([]byte, error) {
 // Peek returns the next n bytes without advancing the reader. It waits until it has
 // read at least n bytes or error has occurred such as connection closed or read timeout.
 // The bytes stop being valid at the next ReadN or Release call.
-func (tc *tcpconn) Peek(n int) ([]byte, error) {
-	if !tc.IsActive() {
-		return tc.closedReadBuf.Peek(n)
-	}
-	if !tc.beginJobSafely(apiRead) {
+func (tc *tcpconn) Peek(n int) (bytes []byte, err error) {
+	isLocked := false
+	defer func() {
+		// release apiRead lock to avoid deadlock with closedFinished
+		if isLocked {
+			tc.endJobSafely(apiRead)
+		}
+		// if conn is closed,  wait storeReadBuffer finished and read from closedReadBuf
+		if tc.needReadFromClosedReadBuf(err) {
+			tc.waitReadFromClosedReadBuf()
+			bytes, err = tc.closedReadBuf.Peek(n)
+		}
+	}()
+
+	if isLocked = tc.beginJobSafely(apiRead); !isLocked {
 		return nil, ErrConnClosed
 	}
-	defer tc.endJobSafely(apiRead)
 
 	if err := tc.waitRead(n); err != nil {
 		return nil, err
@@ -178,14 +215,24 @@ func (tc *tcpconn) Peek(n int) ([]byte, error) {
 
 // Skip skips the next n bytes and advances the reader. It waits until the underlayer has at
 // least n bytes or error has occurred such as connection closed or read timeout.
-func (tc *tcpconn) Skip(n int) error {
-	if !tc.IsActive() {
-		return tc.closedReadBuf.Skip(n)
-	}
-	if !tc.beginJobSafely(apiRead) {
+func (tc *tcpconn) Skip(n int) (err error) {
+	isLocked := false
+	defer func() {
+		// release apiRead lock to avoid deadlock with closedFinished
+		if isLocked {
+			tc.endJobSafely(apiRead)
+		}
+		// if conn is closed, lock closeProcess job to make sure storeReadBuffer finished and read from closedReadBuf
+		if tc.needReadFromClosedReadBuf(err) {
+			tc.waitReadFromClosedReadBuf()
+			err = tc.closedReadBuf.Skip(n)
+		}
+	}()
+
+	if isLocked = tc.beginJobSafely(apiRead); !isLocked {
+		// lock failed, conn is closed
 		return ErrConnClosed
 	}
-	defer tc.endJobSafely(apiRead)
 
 	if err := tc.waitRead(n); err != nil {
 		return err
@@ -229,9 +276,13 @@ func (tc *tcpconn) waitRead(n int) error {
 	return nil
 }
 
-func (tc *tcpconn) timeoutError() error {
-	err := fmt.Errorf("read tcp %s->%s: i/o timeout",
-		tc.LocalAddr().String(), tc.RemoteAddr().String())
+func (tc *tcpconn) readTimeoutErr() error {
+	err := fmt.Errorf("read tcp %s->%s: i/o timeout", tc.RemoteAddr().String(), tc.LocalAddr().String())
+	return netError{error: err, isTimeout: true}
+}
+
+func (tc *tcpconn) writeTimeoutErr() error {
+	err := fmt.Errorf("write tcp %s->%s: i/o timeout", tc.LocalAddr().String(), tc.RemoteAddr().String())
 	return netError{error: err, isTimeout: true}
 }
 
@@ -239,7 +290,7 @@ func (tc *tcpconn) waitReadWithTimeout(n int) error {
 	tc.rtimer.Start()
 	select {
 	case <-tc.rtimer.Wait():
-		return tc.timeoutError()
+		return tc.readTimeoutErr()
 	default:
 	}
 	for tc.inBuffer.LenRead() < n {
@@ -250,7 +301,10 @@ func (tc *tcpconn) waitReadWithTimeout(n int) error {
 		case <-tc.readTrigger:
 			continue
 		case <-tc.rtimer.Wait():
-			return tc.timeoutError()
+			if tc.inBuffer.LenRead() >= n {
+				return nil
+			}
+			return tc.readTimeoutErr()
 		}
 	}
 	return nil
@@ -266,7 +320,7 @@ func (tc *tcpconn) Write(b []byte) (int, error) {
 // Writev provides multiple data slice write in order.
 func (tc *tcpconn) Writev(p ...[]byte) (int, error) {
 	if tc.wtimer != nil && tc.wtimer.Expired() {
-		return 0, tc.timeoutError()
+		return 0, tc.writeTimeoutErr()
 	}
 	if !tc.beginJobSafely(apiWrite) {
 		return 0, ErrConnClosed
@@ -376,6 +430,8 @@ func (tc *tcpconn) flush() error {
 
 // Close closes the tcpconn safely, it can be called multiple times concurrently.
 func (tc *tcpconn) Close() error {
+	// mark conn as closed and close read trigger firstly
+	// to release apiRead lock
 	if !tc.beginJobSafely(closeAll) {
 		return nil
 	}
@@ -387,8 +443,13 @@ func (tc *tcpconn) Close() error {
 	// Stop all jobs safely.
 	tc.closeAllJobs()
 
-	// all job closed, restore read buffer to closedBuffer.
+	// read buffer to closedBuffer.
+	// execute after all jobs closed to avoid concurrent modified inBuffer.
 	tc.storeReadBuffer()
+	// close closedTrigger to wakeup all routines which try to read from closedReadBuf.
+	// close before closeHandle to avoid Read/ReadN/Peek/Next/Skip blocked in closeHandle.
+	// close after storeReadBuffer to make sure storeReadBuffer finished.
+	close(tc.closedFinished)
 
 	// Execute user-defined closing process.
 	if closeHandle := tc.getOnClosed(); closeHandle != nil {
@@ -824,6 +885,24 @@ func (tc *tcpconn) storeReadBuffer() error {
 		return err
 	}
 
-	tc.closedReadBuf.Initialize(buf[:n])
+	tc.closedReadBuf.Initialize(buf[:n], ErrConnClosed)
 	return nil
+}
+
+// check if need read from closedReadBuf
+func (tc *tcpconn) needReadFromClosedReadBuf(err error) bool {
+	return !tc.IsActive() && errors.Is(err, ErrConnClosed)
+}
+
+// waitReadFromClosedReadBuf wait read from closedReadBuf
+func (tc *tcpconn) waitReadFromClosedReadBuf() {
+	select {
+	case <-tc.closedFinished:
+		// closedFinished is closed, storeReadBuffer finished, read from closedReadBuf
+		return
+	case <-time.After(10 * time.Millisecond):
+		// defensive, close closedFinished to unblock waitReadFromClosedReadBuf
+		log.Infof("tcpconn waitReadFromClosedReadBuf timeout")
+		return
+	}
 }

--- a/tcpconn_test.go
+++ b/tcpconn_test.go
@@ -16,6 +16,7 @@ package tnet_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -163,6 +164,69 @@ func TestConnClose_APIClose(t *testing.T) {
 			assert.Nil(t, server.Close())
 			assert.False(t, server.IsActive())
 		},
+	})
+}
+
+func TestConnCloseOnWaitingRead(t *testing.T) {
+	doTestCase(t, testCase{
+		name: "close on waiting read",
+		servHandle: func(t *testing.T, conn tnet.Conn, ch chan int) error {
+			_, err := conn.Read(make([]byte, 1024))
+			assert.Nil(t, err)
+			fmt.Println("server read")
+			<-ch
+			conn.Close()
+			return nil
+		},
+		clientHandle: func(t *testing.T, conn net.Conn, ch chan int) {
+			_, err := conn.Write(helloWorld)
+			assert.Nil(t, err)
+
+			go func() {
+				// sleep 10ms to make sure conn enter waiting read
+				time.Sleep(10 * time.Millisecond)
+				ch <- 1
+			}()
+			n, err := conn.Read(make([]byte, 1024))
+
+			assert.Equal(t, tnet.ErrConnClosed, err)
+			assert.Equal(t, 0, n)
+		},
+		ctrlHandle: func(t *testing.T, server tnet.Conn, client net.Conn, ch chan int) {
+			assert.False(t, server.IsActive())
+		},
+		isTnetCliConn: true,
+	})
+}
+
+func TestServerWriteAndClose(t *testing.T) {
+	doTestCase(t, testCase{
+		name: "server write and close",
+		servHandle: func(t *testing.T, conn tnet.Conn, ch chan int) error {
+			_, err := conn.Write(helloWorld)
+			assert.Nil(t, err)
+			err = conn.Close()
+			assert.Nil(t, err)
+			ch <- 1
+			return nil
+		},
+		clientHandle: func(t *testing.T, conn net.Conn, ch chan int) {
+			_, err := conn.Write(helloWorld)
+			assert.Nil(t, err)
+			buf := make([]byte, 1024)
+			n, err := conn.Read(buf)
+			assert.Nil(t, err)
+			assert.Equal(t, helloWorld, buf[:n])
+			<-ch
+			time.Sleep(1 * time.Millisecond)
+			tcpconn, ok := conn.(tnet.Conn)
+			assert.True(t, ok)
+			assert.False(t, tcpconn.IsActive())
+		},
+		ctrlHandle: func(t *testing.T, server tnet.Conn, client net.Conn, ch chan int) {
+			assert.False(t, server.IsActive())
+		},
+		isTnetCliConn: true,
 	})
 }
 

--- a/tcplistener.go
+++ b/tcplistener.go
@@ -87,14 +87,15 @@ func (t *tcpListener) accept(handle OnTCPOpened) (net.Conn, error) {
 			laddr:   localAddr,
 			raddr:   netutil.SockaddrToTCPOrUnixAddr(sa),
 		},
-		readTrigger: make(chan struct{}, 1),
+		readTrigger:    make(chan struct{}, 1),
+		closedFinished: make(chan struct{}, 1),
 	}
 	if !MassiveConnections.Load() {
 		conn.writevData = iovec.NewIOData(iovec.WithLength(systype.MaxLen))
 	}
 	conn.inBuffer.Initialize()
 	conn.outBuffer.Initialize()
-	conn.closedReadBuf.Initialize(nil)
+	conn.closedReadBuf.Initialize(nil, ErrConnClosed)
 	if handle != nil {
 		if err := handle(conn); err != nil {
 			conn.Close()

--- a/tcplistener_test.go
+++ b/tcplistener_test.go
@@ -26,6 +26,11 @@ import (
 	"trpc.group/trpc-go/tnet/internal/netutil"
 )
 
+const (
+	listenerAcceptTimeout  = time.Second
+	listenerAcceptInterval = 10 * time.Millisecond
+)
+
 func TestListen(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -95,7 +100,13 @@ func TestListenerAccept(t *testing.T) {
 			require.Nil(t, err)
 			defer client.Close()
 
-			conn, err := ln.Accept()
+			var conn net.Conn
+			require.Eventually(t, func() bool {
+				conn, err = ln.Accept()
+				return err == nil && conn != nil
+			}, listenerAcceptTimeout, listenerAcceptInterval, "accept connection failed: %v", err)
+			require.NotNil(t, conn)
+			defer conn.Close()
 			c := conn.(*tcpconn)
 			t.Logf("conn size: %v\n", unsafe.Sizeof(*c))
 			t.Logf("c.writevData.IsNil(): %v\n", c.writevData.IsNil())


### PR DESCRIPTION
## Summary
- add context-aware TCP dialing while keeping existing `DialTCP` behavior
- fix TCP read paths racing with connection close so buffered data remains readable after close
- fix buffer edge cases including node block size adjustment and zero-length `Peek`/`Next` calls
- wrap oversized UDP packet writes with `unix.EMSGSIZE` and stabilize listener accept tests

## Compatibility
- `DialContextTCP` is additive; existing `DialTCP` callers keep the same signature
- `Service` and public connection interfaces are unchanged
- all imports and module paths stay on the public repository path

## Validation
- `go test ./internal/buffer . -run 'Test(Buffer|FixedReadBuffer|TCP|Dial|WriteTo|Listener)' -count=1`
- `go test $(go list ./... | grep -v /internal/reuseport) -count=1`