### PR TITLE
websocket: support client handshake hooks

### DIFF
--- a/extensions/websocket/README.md
+++ b/extensions/websocket/README.md
@@ -14,6 +14,31 @@ Features:
 * Customized control frame handler for Ping/Pong/Close.
 * Set the message type of the connection to use Read/Write API directly.
 * Combined writes optimization to merge header and payload into a single syscall.
+* Client handshake header injection and response header hooks.
+
+## Handshake Headers
+
+You can write additional HTTP headers to the client handshake request and inspect
+non-WebSocket headers from the handshake response.
+
+Note that the key/value bytes received by callback are only valid until the
+callback returns.
+
+To inspect a non-101 handshake response, use `WithClientOnHandshakeResponseStatusError`.
+
+```go
+reqHeader := http.Header{}
+reqHeader.Set("X-Token", "abc")
+
+opts := []websocket.ClientOption{
+    websocket.WithClientHandshakeRequestHeaderHTTP(reqHeader),
+    websocket.WithClientOnHandshakeResponseHeader(func(key, value []byte) error {
+        // Copy key/value if you need to keep them after this callback returns.
+        return nil
+    }),
+}
+conn, err := websocket.Dial(url, opts...)
+```
 
 ## Combined Writes Optimization
 

--- a/extensions/websocket/README_cn.md
+++ b/extensions/websocket/README_cn.md
@@ -14,6 +14,29 @@ websocket 扩展结合了 [tnet](https://trpc.group/trpc-go/tnet) 和 [gobwas/ws
 * 可对控制帧进行自定义处理
 * 可以通过选项设置连接上的消息类型，从而直接使用 Read/Write API
 * 提供了合并写入优化，可以将消息头和负载合并为一次系统调用写入
+* 支持客户端握手 Header 注入与响应 Header 回调
+
+## 握手 Header
+
+客户端可以在握手请求中写入额外的 HTTP Header，并在握手响应中读取非 WebSocket 的 Header。
+
+注意：回调里收到的 key/value 字节切片仅在回调返回前有效，如需保留请自行拷贝。
+
+如需在握手返回非 101 状态码时检查响应内容，可使用 `WithClientOnHandshakeResponseStatusError`。
+
+```go
+reqHeader := http.Header{}
+reqHeader.Set("X-Token", "abc")
+
+opts := []websocket.ClientOption{
+    websocket.WithClientHandshakeRequestHeaderHTTP(reqHeader),
+    websocket.WithClientOnHandshakeResponseHeader(func(key, value []byte) error {
+        // Copy key/value if you need to keep them after this callback returns.
+        return nil
+    }),
+}
+conn, err := websocket.Dial(url, opts...)
+```
 
 ## 合并写入优化
 

--- a/extensions/websocket/client.go
+++ b/extensions/websocket/client.go
@@ -14,8 +14,10 @@
 package websocket
 
 import (
+	"bytes"
 	stdtls "crypto/tls"
 	"fmt"
+	"io"
 	neturl "net/url"
 	"strings"
 
@@ -37,16 +39,36 @@ func Dial(url string, opts ...ClientOption) (Conn, error) {
 		opt(&options)
 	}
 	c, err := dial(u, &options)
-	dialer := ws.Dialer{
-		Protocols: options.subprotocols,
-	}
-	_, handshake, err := dialer.Upgrade(c, u)
 	if err != nil {
 		return nil, err
+	}
+	dialer := ws.Dialer{
+		Protocols:     options.subprotocols,
+		Header:        options.handshakeHeader,
+		OnHeader:      options.onHandshakeHeader,
+		OnStatusError: options.onHandshakeStatusError,
+	}
+	br, handshake, err := dialer.Upgrade(c, u)
+	if err != nil {
+		return nil, err
+	}
+	var source io.Reader
+	if br != nil {
+		n := br.Buffered()
+		if n > 0 {
+			prefix := make([]byte, n)
+			if _, err := io.ReadFull(br, prefix); err != nil {
+				ws.PutReader(br)
+				return nil, err
+			}
+			source = io.MultiReader(bytes.NewReader(prefix), c)
+		}
+		ws.PutReader(br)
 	}
 	wc := &conn{
 		raw:           c,
 		role:          ws.StateClientSide,
+		source:        source,
 		subprotocol:   handshake.Protocol,
 		messageType:   options.messageType,
 		combineWrites: options.combineWrites,

--- a/extensions/websocket/client_test.go
+++ b/extensions/websocket/client_test.go
@@ -1,0 +1,268 @@
+package websocket_test
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/tnet/extensions/websocket"
+)
+
+type handshakeObservation struct {
+	wsKey  string
+	xToken string
+	err    error
+}
+
+type staticHandshakeHeader string
+
+func (h staticHandshakeHeader) WriteTo(w io.Writer) (int64, error) {
+	n, err := io.WriteString(w, string(h))
+	return int64(n), err
+}
+
+func TestClientHandshakeRequestHeader(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	serverDone := make(chan struct{})
+	t.Cleanup(func() { close(serverDone) })
+	obsCh := make(chan handshakeObservation, 1)
+	go func() {
+		obs := handshakeObservation{}
+		c, err := ln.Accept()
+		if err != nil {
+			obs.err = err
+			obsCh <- obs
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		if _, err := br.ReadString('\n'); err != nil {
+			obs.err = err
+			obsCh <- obs
+			return
+		}
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				obs.err = err
+				obsCh <- obs
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				break
+			}
+			key, value, ok := strings.Cut(line, ":")
+			if !ok {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			switch strings.ToLower(key) {
+			case "sec-websocket-key":
+				obs.wsKey = value
+			case "x-token":
+				obs.xToken = value
+			}
+		}
+		if obs.wsKey == "" {
+			obs.err = errors.New("missing Sec-WebSocket-Key header")
+			obsCh <- obs
+			return
+		}
+		accept := computeWebSocketAccept(obs.wsKey)
+		resp := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n"
+		if _, err := c.Write([]byte(resp)); err != nil {
+			obs.err = err
+		}
+		obsCh <- obs
+		select {
+		case <-serverDone:
+		case <-time.After(time.Second):
+		}
+	}()
+	c, err := websocket.Dial("ws://"+ln.Addr().String()+"/", websocket.WithClientHandshakeRequestHeader(staticHandshakeHeader("X-Token: abc\r\n")))
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	obs := <-obsCh
+	require.NoError(t, obs.err)
+	require.Equal(t, "abc", obs.xToken)
+}
+
+func TestClientHandshakeHeaderAndBufferedBytes(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	serverDone := make(chan struct{})
+	t.Cleanup(func() { close(serverDone) })
+	obsCh := make(chan handshakeObservation, 1)
+	go func() {
+		obs := handshakeObservation{}
+		c, err := ln.Accept()
+		if err != nil {
+			obs.err = err
+			obsCh <- obs
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		if _, err := br.ReadString('\n'); err != nil {
+			obs.err = err
+			obsCh <- obs
+			return
+		}
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				obs.err = err
+				obsCh <- obs
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				break
+			}
+			key, value, ok := strings.Cut(line, ":")
+			if !ok {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			switch strings.ToLower(key) {
+			case "sec-websocket-key":
+				obs.wsKey = value
+			case "x-token":
+				obs.xToken = value
+			}
+		}
+		if obs.wsKey == "" {
+			obs.err = errors.New("missing Sec-WebSocket-Key header")
+			obsCh <- obs
+			return
+		}
+		accept := computeWebSocketAccept(obs.wsKey)
+		resp := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\nX-Server: ok\r\n\r\n"
+		payload := bytes.Repeat([]byte("a"), 8192)
+		frame := buildTextFrame(payload)
+		if _, err := c.Write(append([]byte(resp), frame...)); err != nil {
+			obs.err = err
+		}
+		obsCh <- obs
+		select {
+		case <-serverDone:
+		case <-time.After(time.Second):
+		}
+	}()
+	reqHeader := http.Header{}
+	reqHeader.Set("X-Token", "abc")
+	var gotServerHeader string
+	c, err := websocket.Dial("ws://"+ln.Addr().String()+"/", websocket.WithClientHandshakeRequestHeaderHTTP(reqHeader), websocket.WithClientOnHandshakeResponseHeader(func(key, value []byte) error {
+		if strings.EqualFold(string(key), "x-server") {
+			gotServerHeader = string(value)
+		}
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "ok", gotServerHeader)
+	require.NoError(t, c.SetReadDeadline(time.Now().Add(time.Second)))
+	tp, msg, err := c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, websocket.Text, tp)
+	require.Equal(t, 8192, len(msg))
+	require.Equal(t, byte('a'), msg[0])
+	require.Equal(t, byte('a'), msg[len(msg)-1])
+	require.NoError(t, c.Close())
+	obs := <-obsCh
+	require.NoError(t, obs.err)
+	require.Equal(t, "abc", obs.xToken)
+}
+
+type statusErrorObservation struct {
+	status int
+	reason string
+	resp   string
+}
+
+func TestClientOnHandshakeResponseStatusError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	statusCh := make(chan statusErrorObservation, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		body := "nope"
+		resp := "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: 4\r\nConnection: close\r\n\r\n" + body
+		_, _ = c.Write([]byte(resp))
+	}()
+	_, err = websocket.Dial("ws://"+ln.Addr().String()+"/", websocket.WithClientOnHandshakeResponseStatusError(func(status int, reason []byte, resp io.Reader) {
+		b, _ := io.ReadAll(io.LimitReader(resp, 1024))
+		statusCh <- statusErrorObservation{status: status, reason: string(reason), resp: string(b)}
+	}))
+	require.Error(t, err)
+	var obs statusErrorObservation
+	require.Eventually(t, func() bool {
+		select {
+		case obs = <-statusCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, 403, obs.status)
+	require.Contains(t, obs.reason, "Forbidden")
+	require.Contains(t, obs.resp, "HTTP/1.1 403 Forbidden")
+	require.Contains(t, obs.resp, "nope")
+}
+
+func computeWebSocketAccept(key string) string {
+	sum := sha1.Sum([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func buildTextFrame(payload []byte) []byte {
+	n := len(payload)
+	if n <= 125 {
+		frame := make([]byte, 2, 2+n)
+		frame[0] = 0x81
+		frame[1] = byte(n)
+		return append(frame, payload...)
+	}
+	if n <= 65535 {
+		frame := make([]byte, 4, 4+n)
+		frame[0] = 0x81
+		frame[1] = 126
+		binary.BigEndian.PutUint16(frame[2:], uint16(n))
+		return append(frame, payload...)
+	}
+	frame := make([]byte, 10, 10+n)
+	frame[0] = 0x81
+	frame[1] = 127
+	binary.BigEndian.PutUint64(frame[2:], uint64(n))
+	return append(frame, payload...)
+}

--- a/extensions/websocket/conn.go
+++ b/extensions/websocket/conn.go
@@ -36,16 +36,16 @@ type conn struct {
 	// leading to the need for an additional lock here to ensure that the packet header and
 	// the packet body are written to the connection as a whole.
 	// Note: This lock does not guarantee concurrent safety when reading message.
-	mu          sync.Mutex
-	raw         rawConnection
-	metaData    interface{}
-	role        ws.State    // ws.StateServerSide or ws.StateClientSide.
-	reader      io.Reader   // connection-wise message type reader for Read.
-	messageType MessageType // connection-wise message type for Read/Write.
-	subprotocol string      // the subprotocol selected during handshake.
-	pingHandler func(c Conn, data []byte) error
-	pongHandler func(c Conn, data []byte) error
-
+	mu            sync.Mutex
+	raw           rawConnection
+	metaData      interface{}
+	role          ws.State    // ws.StateServerSide or ws.StateClientSide.
+	source        io.Reader   // It is used as the frame source for reads.
+	reader        io.Reader   // connection-wise message type reader for Read.
+	messageType   MessageType // connection-wise message type for Read/Write.
+	subprotocol   string      // the subprotocol selected during handshake.
+	pingHandler   func(c Conn, data []byte) error
+	pongHandler   func(c Conn, data []byte) error
 	combineWrites bool // Controls if header and payload writes are combined into a single syscall.
 }
 
@@ -435,11 +435,18 @@ func (c *conn) SetAsyncPongHandler(handler func(Conn, []byte) error) {
 
 func (c *conn) newReader(handler wsutil.FrameHandlerFunc) *wsutil.Reader {
 	return &wsutil.Reader{
-		Source:         c.raw,
+		Source:         c.readSource(),
 		State:          c.role,
 		CheckUTF8:      true,
 		OnIntermediate: handler,
 	}
+}
+
+func (c *conn) readSource() io.Reader {
+	if c.source != nil {
+		return c.source
+	}
+	return c.raw
 }
 
 func (c *conn) newControlFrameHandler() wsutil.FrameHandlerFunc {
@@ -525,6 +532,12 @@ func (c *conn) SetOnRequest(handler Handler) error {
 			return handleWithOptions(conn, handler, &o)
 		})
 	}
+	if tc, ok := c.raw.(tls.Conn); ok {
+		return tc.SetOnRequest(func(tls.Conn) error {
+			o := defaultServerOptions
+			return handleWithOptions(c.raw, handler, &o)
+		})
+	}
 	return errors.New("websocket.conn is expected to have raw to be tnet.Conn in SetOnRequest")
 }
 
@@ -532,6 +545,9 @@ func (c *conn) SetOnRequest(handler Handler) error {
 func (c *conn) SetOnClosed(oc OnClosed) error {
 	if tc, ok := c.raw.(tnet.Conn); ok {
 		return tc.SetOnClosed(onClosed(oc))
+	}
+	if tc, ok := c.raw.(tls.Conn); ok {
+		return tc.SetOnClosed(onClosedTLS(oc))
 	}
 	return errors.New("websocket.conn is expected to have raw to be tnet.Conn in SetOnClosed")
 }

--- a/extensions/websocket/options.go
+++ b/extensions/websocket/options.go
@@ -16,6 +16,8 @@ package websocket
 import (
 	"context"
 	"crypto/tls"
+	"io"
+	"net/http"
 	"time"
 )
 
@@ -147,11 +149,14 @@ func WithServerCombinedWrites(enabled bool) ServerOption {
 }
 
 type clientOptions struct {
-	timeout       time.Duration
-	subprotocols  []string
-	messageType   MessageType
-	tlsConfig     *tls.Config
-	combineWrites bool
+	timeout                time.Duration
+	subprotocols           []string
+	handshakeHeader        HandshakeHeader
+	onHandshakeHeader      func(key, value []byte) error
+	onHandshakeStatusError func(status int, reason []byte, resp io.Reader)
+	messageType            MessageType
+	tlsConfig              *tls.Config
+	combineWrites          bool
 }
 
 func (o *clientOptions) setDefaults() {
@@ -172,6 +177,62 @@ func WithTimeout(timeout time.Duration) ClientOption {
 func WithSubProtocols(subprotocols []string) ClientOption {
 	return func(o *clientOptions) {
 		o.subprotocols = subprotocols
+	}
+}
+
+// WithClientHandshakeRequestHeader provides the option to write additional HTTP headers during handshake request.
+func WithClientHandshakeRequestHeader(header HandshakeHeader) ClientOption {
+	return func(o *clientOptions) {
+		o.handshakeHeader = header
+	}
+}
+
+type handshakeHeaderHTTP http.Header
+
+func (h handshakeHeaderHTTP) WriteTo(w io.Writer) (int64, error) {
+	wr := &handshakeHeaderWriter{w: w}
+	err := http.Header(h).Write(wr)
+	return wr.n, err
+}
+
+// handshakeHeaderWriter implements io.Writer and io.StringWriter to avoid extra allocations in http.Header.Write.
+type handshakeHeaderWriter struct {
+	n int64
+	w io.Writer
+}
+
+// WriteString avoids allocating a temporary []byte when http.Header.Write uses io.WriteString.
+func (w *handshakeHeaderWriter) WriteString(s string) (int, error) {
+	n, err := io.WriteString(w.w, s)
+	w.n += int64(n)
+	return n, err
+}
+
+// Write writes bytes and tracks the total number of bytes written.
+func (w *handshakeHeaderWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	w.n += int64(n)
+	return n, err
+}
+
+// WithClientHandshakeRequestHeaderHTTP provides the option to set HTTP headers for handshake request.
+func WithClientHandshakeRequestHeaderHTTP(header http.Header) ClientOption {
+	return func(o *clientOptions) {
+		o.handshakeHeader = handshakeHeaderHTTP(header)
+	}
+}
+
+// WithClientOnHandshakeResponseHeader provides the option to inspect non-WebSocket headers from the handshake response.
+func WithClientOnHandshakeResponseHeader(onHeader func(key, value []byte) error) ClientOption {
+	return func(o *clientOptions) {
+		o.onHandshakeHeader = onHeader
+	}
+}
+
+// WithClientOnHandshakeResponseStatusError provides the option to inspect response bytes when the server returns a non-101 status.
+func WithClientOnHandshakeResponseStatusError(onStatusError func(status int, reason []byte, resp io.Reader)) ClientOption {
+	return func(o *clientOptions) {
+		o.onHandshakeStatusError = onStatusError
 	}
 }
 

--- a/extensions/websocket/options_test.go
+++ b/extensions/websocket/options_test.go
@@ -14,6 +14,7 @@
 package websocket
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,17 +25,24 @@ func TestCombinedWritesOptions(t *testing.T) {
 		opts := &serverOptions{}
 		WithServerCombinedWrites(true)(opts)
 		assert.True(t, opts.combineWrites)
-
 		WithServerCombinedWrites(false)(opts)
 		assert.False(t, opts.combineWrites)
 	})
-
 	t.Run("client option", func(t *testing.T) {
 		opts := &clientOptions{}
 		WithClientCombinedWrites(true)(opts)
 		assert.True(t, opts.combineWrites)
-
 		WithClientCombinedWrites(false)(opts)
 		assert.False(t, opts.combineWrites)
 	})
+}
+
+func TestHandshakeHeaderWriterWrite(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := &handshakeHeaderWriter{w: buf}
+	n, err := w.Write([]byte("abc"))
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, int64(3), w.n)
+	assert.Equal(t, "abc", buf.String())
 }

--- a/extensions/websocket/websocket.go
+++ b/extensions/websocket/websocket.go
@@ -232,3 +232,8 @@ type Conn interface {
 	// SetOnClosed set on closed function for websocket connection.
 	SetOnClosed(handle OnClosed) error
 }
+
+// HandshakeHeader writes additional HTTP headers during the WebSocket handshake.
+type HandshakeHeader interface {
+	io.WriterTo
+}

--- a/extensions/websocket/websocket_test.go
+++ b/extensions/websocket/websocket_test.go
@@ -72,6 +72,61 @@ func TestClientHandle(t *testing.T) {
 	<-done // Wait for server closing.
 }
 
+func TestWSSClientSetOnRequestAndSetOnClosed(t *testing.T) {
+	serverConnCh := make(chan websocket.Conn, 1)
+	echoedCh := make(chan []byte, 1)
+	done := make(chan struct{})
+	addr, cancel := runServer(t, func(conn websocket.Conn) error {
+		tp, buf, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		require.Equal(t, websocket.Text, tp)
+		echoedCh <- buf
+		return nil
+	}, done, websocket.WithServerTLSConfig(getTLSCfg()), websocket.WithHookAfterHandshake(func(ctx context.Context, c websocket.Conn) error {
+		serverConnCh <- c
+		return nil
+	}))
+	clientConn, err := websocket.Dial(wssURLPrefix+addr, websocket.WithClientTLSConfig(&stdtls.Config{InsecureSkipVerify: true}))
+	require.NoError(t, err)
+	closedCh := make(chan struct{}, 1)
+	clientHandle := func(conn websocket.Conn) error {
+		tp, buf, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		require.Equal(t, websocket.Text, tp)
+		return conn.WriteMessage(websocket.Text, buf)
+	}
+	require.NoError(t, clientConn.SetOnRequest(clientHandle))
+	require.NoError(t, clientConn.SetOnClosed(func(c websocket.Conn) error {
+		closedCh <- struct{}{}
+		return nil
+	}))
+	var serverConn websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(time.Second):
+		t.Fatal("server connection was not established")
+	}
+	require.NoError(t, serverConn.WriteMessage(websocket.Text, world))
+	select {
+	case echoed := <-echoedCh:
+		require.Equal(t, world, echoed)
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive echoed message")
+	}
+	require.NoError(t, clientConn.Close())
+	select {
+	case <-closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("client close hook was not called")
+	}
+	cancel()
+	<-done // Wait for server closing.
+}
+
 func TestServer(t *testing.T) {
 	runTestWithHandles(t, func(conn websocket.Conn) error {
 		tp, buf, err := conn.ReadMessage()

--- a/tcplistener_test.go
+++ b/tcplistener_test.go
@@ -26,6 +26,11 @@ import (
 	"trpc.group/trpc-go/tnet/internal/netutil"
 )
 
+const (
+	listenerAcceptTimeout  = time.Second
+	listenerAcceptInterval = 10 * time.Millisecond
+)
+
 func TestListen(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -95,7 +100,13 @@ func TestListenerAccept(t *testing.T) {
 			require.Nil(t, err)
 			defer client.Close()
 
-			conn, err := ln.Accept()
+			var conn net.Conn
+			require.Eventually(t, func() bool {
+				conn, err = ln.Accept()
+				return err == nil && conn != nil
+			}, listenerAcceptTimeout, listenerAcceptInterval, "accept connection failed: %v", err)
+			require.NotNil(t, conn)
+			defer conn.Close()
 			c := conn.(*tcpconn)
 			t.Logf("conn size: %v\n", unsafe.Sizeof(*c))
 			t.Logf("c.writevData.IsNil(): %v\n", c.writevData.IsNil())


### PR DESCRIPTION
## Summary
- allow websocket clients to add handshake request headers
- expose hooks for handshake response headers and non-101 status responses
- preserve buffered bytes returned by the websocket upgrader before normal frame reads
- support WSS client `SetOnRequest` and `SetOnClosed` hooks

## Compatibility
- all APIs are additive options or interfaces
- existing websocket dial behavior is unchanged when no new option is set
- public module paths are preserved

## Validation
- `go test . -run 'TestClientHandshakeRequestHeader|TestClientHandshakeHeaderAndBufferedBytes|TestClientOnHandshakeResponseStatusError' -count=1`
- `go test . -run 'TestWSSClientSetOnRequestAndSetOnClosed' -count=1`