### PR TITLE
tnet: add outbound buffer limit

### DIFF
--- a/extensions/websocket/conn.go
+++ b/extensions/websocket/conn.go
@@ -72,6 +72,26 @@ type rawConn struct {
 	tls.Conn
 }
 
+// OutboundBuffered returns the current outbound buffered bytes for c.
+// It returns 0 if c is nil or is not backed by tnet TCP.
+func OutboundBuffered(c Conn) int {
+	wc, ok := c.(*conn)
+	if !ok || wc == nil {
+		return 0
+	}
+	switch raw := wc.raw.(type) {
+	case tnet.Conn:
+		return tnet.OutboundBuffered(raw)
+	case *rawConn:
+		if raw == nil {
+			return 0
+		}
+		return tls.OutboundBuffered(raw.Conn)
+	default:
+		return 0
+	}
+}
+
 // Writev implements websocket.RawConn interface.
 func (c *rawConn) Writev(p ...[]byte) (int, error) {
 	var num int

--- a/extensions/websocket/options.go
+++ b/extensions/websocket/options.go
@@ -41,6 +41,7 @@ type serverOptions struct {
 	idleTimeout         time.Duration
 	onClosed            func(Conn) error
 	combineWrites       bool
+	outboundBufferLimit int
 }
 
 // ServerOption is the type for a single server option.
@@ -143,6 +144,17 @@ func WithOnClosed(onClosed func(Conn) error) ServerOption {
 func WithServerCombinedWrites(enabled bool) ServerOption {
 	return func(o *serverOptions) {
 		o.combineWrites = enabled
+	}
+}
+
+// WithServerOutboundBufferLimit sets the max outbound buffered bytes for each server connection.
+// If limit is less than or equal to 0, the limit check is disabled.
+func WithServerOutboundBufferLimit(limit int) ServerOption {
+	return func(o *serverOptions) {
+		if o == nil {
+			return
+		}
+		o.outboundBufferLimit = limit
 	}
 }
 

--- a/extensions/websocket/options_test.go
+++ b/extensions/websocket/options_test.go
@@ -27,6 +27,9 @@ func TestCombinedWritesOptions(t *testing.T) {
 
 		WithServerCombinedWrites(false)(opts)
 		assert.False(t, opts.combineWrites)
+		WithServerOutboundBufferLimit(1024)(opts)
+		assert.Equal(t, 1024, opts.outboundBufferLimit)
+		WithServerOutboundBufferLimit(1024)(nil)
 	})
 
 	t.Run("client option", func(t *testing.T) {

--- a/extensions/websocket/server.go
+++ b/extensions/websocket/server.go
@@ -38,20 +38,32 @@ func NewService(ln net.Listener, handler Handler, opts ...ServerOption) (tnet.Se
 	if options.tlsConfig != nil {
 		return tls.NewService(ln, func(c tls.Conn) error {
 			return handleWithOptions(&rawConn{Conn: c}, handler, &options)
-		}, tls.WithTCPKeepAlive(options.keepAlive),
-			tls.WithServerIdleTimeout(options.idleTimeout),
-			tls.WithServerTLSConfig(options.tlsConfig),
-			tls.WithOnClosed(onClosedTLS(options.onClosed)),
-			tls.WithServerFlushWrite(true), // Enable flush write for websocket.
-		)
+		}, tlsServiceOptions(&options)...)
 	}
 	return tnet.NewTCPService(ln, func(c tnet.Conn) error {
 		return handleWithOptions(c, handler, &options)
-	}, tnet.WithTCPKeepAlive(options.keepAlive),
+	}, tcpServiceOptions(&options)...)
+}
+
+func tlsServiceOptions(options *serverOptions) []tls.ServerOption {
+	return []tls.ServerOption{
+		tls.WithTCPKeepAlive(options.keepAlive),
+		tls.WithServerIdleTimeout(options.idleTimeout),
+		tls.WithServerTLSConfig(options.tlsConfig),
+		tls.WithOnClosed(onClosedTLS(options.onClosed)),
+		tls.WithServerFlushWrite(true), // Enable flush write for websocket.
+		tls.WithServerOutboundBufferLimit(options.outboundBufferLimit),
+	}
+}
+
+func tcpServiceOptions(options *serverOptions) []tnet.Option {
+	return []tnet.Option{
+		tnet.WithTCPKeepAlive(options.keepAlive),
 		tnet.WithTCPIdleTimeout(options.idleTimeout),
 		tnet.WithOnTCPClosed(onClosed(options.onClosed)),
 		tnet.WithFlushWrite(true), // Enable flushwrite for websocket.
-	)
+		tnet.WithTCPOutboundBufferLimit(options.outboundBufferLimit),
+	}
 }
 
 type graderKey struct{}

--- a/extensions/websocket/websocket_test.go
+++ b/extensions/websocket/websocket_test.go
@@ -248,6 +248,61 @@ func TestWritev(t *testing.T) {
 	}, nil)
 }
 
+func TestServerOutboundBufferLimitWriteMessage(t *testing.T) {
+	payload := bytes.Repeat([]byte("a"), 8*1024)
+	for _, combineWrites := range []bool{false, true} {
+		name := "without_combined_writes"
+		if combineWrites {
+			name = "with_combined_writes"
+		}
+		t.Run(name, func(t *testing.T) {
+			serverErr := make(chan error, 2)
+			runTestWithHandles(t, func(conn websocket.Conn) error {
+				_, _, err := conn.ReadMessage()
+				if err != nil {
+					serverErr <- err
+					return err
+				}
+				require.Zero(t, websocket.OutboundBuffered(conn))
+				err = conn.WriteMessage(websocket.Binary, payload)
+				serverErr <- err
+				return err
+			}, func(conn websocket.Conn) error {
+				if err := conn.WriteMessage(websocket.Binary, hello); err != nil {
+					return err
+				}
+				err := waitServerError(serverErr)
+				require.True(t, errors.Is(err, tnet.ErrOutboundBufferLimitExceeded), "err: %+v", err)
+				return nil
+			}, nil,
+				websocket.WithServerOutboundBufferLimit(1024),
+				websocket.WithServerCombinedWrites(combineWrites))
+		})
+	}
+}
+
+func TestServerOutboundBufferLimitWritevMessage(t *testing.T) {
+	serverErr := make(chan error, 2)
+	payload := bytes.Repeat([]byte("a"), 8*1024)
+	runTestWithHandles(t, func(conn websocket.Conn) error {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			serverErr <- err
+			return err
+		}
+		err = conn.WritevMessage(websocket.Binary, payload, []byte("b"))
+		serverErr <- err
+		return err
+	}, func(conn websocket.Conn) error {
+		if err := conn.WriteMessage(websocket.Binary, hello); err != nil {
+			return err
+		}
+		err := waitServerError(serverErr)
+		require.True(t, errors.Is(err, tnet.ErrOutboundBufferLimitExceeded), "err: %+v", err)
+		return nil
+	}, nil, websocket.WithServerOutboundBufferLimit(1024))
+}
+
 func TestSubProtocols(t *testing.T) {
 	runTestWithHandles(t, func(conn websocket.Conn) error {
 		require.Equal(t, "superchat", conn.Subprotocol())
@@ -280,6 +335,15 @@ func TestSubProtocols(t *testing.T) {
 		}
 		return "", true
 	}))
+}
+
+func waitServerError(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(5 * time.Second):
+		return errors.New("timeout waiting server error")
+	}
 }
 
 func TestReadWrite(t *testing.T) {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -474,14 +474,38 @@ func (b *Buffer) Writev(safeWrite bool, bs ...[]byte) int {
 	return b.linkFrom(bs...)
 }
 
+// WritevLimited appends data slice to buffer unless the written data would exceed limit.
+// If limit is less than or equal to 0, the limit check is disabled.
+func (b *Buffer) WritevLimited(safeWrite bool, limit int, bs ...[]byte) (int, error) {
+	if b == nil {
+		return 0, ErrInvalidParam
+	}
+	if limit <= 0 {
+		return b.Writev(safeWrite, bs...), nil
+	}
+	length := byteSlicesLen(bs...)
+	if length == 0 {
+		return 0, nil
+	}
+	b.wlock.Lock()
+	defer b.wlock.Unlock()
+	if length > limit-b.LenRead() {
+		return 0, ErrBufferFull
+	}
+	if safeWrite {
+		return b.copyFromLocked(length, bs...), nil
+	}
+	return b.linkFromLocked(bs...), nil
+}
+
 func (b *Buffer) copyFrom(bs ...[]byte) int {
 	b.wlock.Lock()
 	defer b.wlock.Unlock()
+	return b.copyFromLocked(byteSlicesLen(bs...), bs...)
+}
+
+func (b *Buffer) copyFromLocked(length int, bs ...[]byte) int {
 	b.prepareFill()
-	var length int
-	for i := range bs {
-		length += len(bs[i])
-	}
 	b.malloc(b.calNodes(length))
 	var copied int
 	for i := range bs {
@@ -504,12 +528,24 @@ func (b *Buffer) copyFromSingleByteSlice(buf []byte) int {
 }
 
 func (b *Buffer) linkFrom(bs ...[]byte) int {
-	total := len(bs)
 	b.wlock.Lock()
 	defer b.wlock.Unlock()
+	return b.linkFromLocked(bs...)
+}
+
+func (b *Buffer) linkFromLocked(bs ...[]byte) int {
+	total := len(bs)
 	linked, length := b.linkWithExistingNodes(bs...)
 	if linked < total {
 		length += b.linkWithNewNodes(bs[linked:]...)
+	}
+	return length
+}
+
+func byteSlicesLen(bs ...[]byte) int {
+	var length int
+	for i := range bs {
+		length += len(bs[i])
 	}
 	return length
 }

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -89,6 +89,50 @@ func TestBuffer_Writev(t *testing.T) {
 	assert.Equal(t, len(s1)+len(s2)+len(s3), n)
 }
 
+func TestBuffer_WritevLimited(t *testing.T) {
+	t.Run("safe write reaches limit", func(t *testing.T) {
+		b := New()
+		defer Free(b)
+
+		n, err := b.WritevLimited(true, 6, []byte("abc"), []byte("def"))
+		assert.NoError(t, err)
+		assert.Equal(t, 6, n)
+		assert.Equal(t, 6, b.LenRead())
+	})
+
+	t.Run("unsafe write rejects overflow without changing length", func(t *testing.T) {
+		b := New()
+		defer Free(b)
+
+		n, err := b.WritevLimited(false, 5, []byte("abcde"))
+		assert.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, 5, b.LenRead())
+
+		n, err = b.WritevLimited(false, 5, []byte("f"))
+		assert.True(t, errors.Is(err, ErrBufferFull))
+		assert.Zero(t, n)
+		assert.Equal(t, 5, b.LenRead())
+	})
+
+	t.Run("zero disables limit", func(t *testing.T) {
+		b := New()
+		defer Free(b)
+
+		n, err := b.WritevLimited(true, 0, []byte("abc"), []byte("def"))
+		assert.NoError(t, err)
+		assert.Equal(t, 6, n)
+		assert.Equal(t, 6, b.LenRead())
+	})
+
+	t.Run("nil buffer", func(t *testing.T) {
+		var b *Buffer
+		n, err := b.WritevLimited(true, 1, []byte("a"))
+		assert.True(t, errors.Is(err, ErrInvalidParam))
+		assert.Zero(t, n)
+	})
+}
+
 func TestBuffer_Write(t *testing.T) {
 	// 无参数
 	b := New()

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -62,18 +62,25 @@ const (
 	EpollEvents
 	TaskAssigned
 
-	// Keep it last.
+	// Keep it last in this iota block for backward compatibility.
 
 	Max
 )
 
+const (
+	// TCPOutboundBufferLimitExceeded is the number of times outbound buffer limit was exceeded.
+	TCPOutboundBufferLimitExceeded = Max
+
+	metricNum = TCPOutboundBufferLimitExceeded + 1
+)
+
 var (
-	metrics [Max]atomic.Uint64
+	metrics [metricNum]atomic.Uint64
 )
 
 // Add metrics counter.
 func Add(name int, delta uint64) {
-	if name >= Max {
+	if name >= metricNum {
 		return
 	}
 	metrics[name].Add(delta)
@@ -81,7 +88,7 @@ func Add(name int, delta uint64) {
 
 // Get one metric counter.
 func Get(name int) uint64 {
-	if name >= Max {
+	if name >= metricNum {
 		return 0
 	}
 	return metrics[name].Load()
@@ -90,7 +97,7 @@ func Get(name int) uint64 {
 // GetAll get all metrics.
 func GetAll() [Max]uint64 {
 	var m [Max]uint64
-	for i := range metrics {
+	for i := range m {
 		m[i] = metrics[i].Load()
 	}
 	return m
@@ -100,30 +107,32 @@ func GetAll() [Max]uint64 {
 // It will block d duration, and then prints metrics info.
 func ShowMetricsOfPeriod(d time.Duration) {
 	old := GetAll()
+	oldOutboundBufferLimitExceeded := Get(TCPOutboundBufferLimitExceeded)
 	<-time.After(d)
 	new := GetAll()
+	outboundBufferLimitExceeded := Get(TCPOutboundBufferLimitExceeded) - oldOutboundBufferLimitExceeded
 	var m [Max]uint64
-	for i := range metrics {
+	for i := range m {
 		m[i] = new[i] - old[i]
 	}
-	showAll(m)
+	showAll(m, outboundBufferLimitExceeded)
 }
 
 // ShowMetrics shows metric info in console.
 func ShowMetrics() {
 	m := GetAll()
-	showAll(m)
+	showAll(m, Get(TCPOutboundBufferLimitExceeded))
 }
 
-func showAll(m [Max]uint64) {
+func showAll(m [Max]uint64, outboundBufferLimitExceeded uint64) {
 	log.Debug("######### tnet metrics (", time.Now().Format("2006-01-02 15:04:05"), ") ###########")
-	showTCPMetrics(m)
+	showTCPMetrics(m, outboundBufferLimitExceeded)
 	showUDPMetrics(m)
 	showEpollMetrics(m)
 	log.Debugf("%-59s: %d", "# number of task assigned (doTask)", m[TaskAssigned])
 }
 
-func showTCPMetrics(m [Max]uint64) {
+func showTCPMetrics(m [Max]uint64, outboundBufferLimitExceeded uint64) {
 	log.Debugf("%-59s: %d", "# TCP - number of Readv system calls", m[TCPReadvCalls])
 	log.Debugf("%-59s: %d", "# TCP - number of failed Readv system calls", m[TCPReadvFails])
 	readvSucc := m[TCPReadvCalls] - m[TCPReadvFails]
@@ -143,6 +152,7 @@ func showTCPMetrics(m [Max]uint64) {
 	log.Debugf("%-59s: %d", "# TCP - number of connections closed", m[TCPConnsClose])
 	log.Debugf("%-59s: %d", "# TCP - number of times postpone write switched off", m[TCPPostponeWriteOff])
 	log.Debugf("%-59s: %d", "# TCP - number of times postpone write switched on", m[TCPPostponeWriteOn])
+	log.Debugf("%-59s: %d", "# TCP - number of outbound buffer limit exceeded", outboundBufferLimitExceeded)
 }
 
 func showUDPMetrics(m [Max]uint64) {

--- a/metrics/metric_test.go
+++ b/metrics/metric_test.go
@@ -32,6 +32,7 @@ func TestMetrics(t *testing.T) {
 	metrics.Add(metrics.EpollEvents, 99)
 	metrics.Add(metrics.TCPWritevCalls, 191)
 	metrics.Add(metrics.TCPWritevBlocks, 1191)
+	metrics.Add(metrics.TCPOutboundBufferLimitExceeded, 1)
 	metrics.Add(metrics.TCPReadvCalls, 191)
 	metrics.Add(metrics.TCPReadvBytes, 1191)
 	metrics.Add(metrics.UDPRecvMMsgCalls, 191)
@@ -40,4 +41,14 @@ func TestMetrics(t *testing.T) {
 	assert.Equal(t, uint64(0), metrics.Get(metrics.Max+1))
 	metrics.ShowMetrics()
 	metrics.ShowMetricsOfPeriod(time.Millisecond)
+}
+
+func TestMetricConstantsKeepBackwardCompatibility(t *testing.T) {
+	assert.Equal(t, 13, metrics.UDPRecvMMsgCalls)
+	assert.Equal(t, 24, metrics.EpollWait)
+	assert.Equal(t, 27, metrics.TaskAssigned)
+	assert.Equal(t, 28, metrics.Max)
+	assert.Equal(t, metrics.Max, metrics.TCPOutboundBufferLimitExceeded)
+	metrics.Add(metrics.TCPOutboundBufferLimitExceeded, 1)
+	assert.Greater(t, metrics.Get(metrics.TCPOutboundBufferLimitExceeded), uint64(0))
 }

--- a/options.go
+++ b/options.go
@@ -71,6 +71,7 @@ type options struct {
 	tcpIdleTimeout            time.Duration
 	tcpWriteIdleTimeout       time.Duration
 	tcpReadIdleTimeout        time.Duration
+	tcpOutboundBufferLimit    int
 	nonblocking               bool
 	safeWrite                 bool
 	maxUDPPacketSize          int
@@ -108,6 +109,17 @@ func WithTCPReadIdleTimeout(idleTimeout time.Duration) Option {
 func WithTCPIdleTimeout(idleTimeout time.Duration) Option {
 	return Option{func(op *options) {
 		op.tcpIdleTimeout = idleTimeout
+	}}
+}
+
+// WithTCPOutboundBufferLimit sets the max outbound buffered bytes for each TCP connection.
+// If limit is less than or equal to 0, the limit check is disabled.
+func WithTCPOutboundBufferLimit(limit int) Option {
+	return Option{func(op *options) {
+		if op == nil {
+			return
+		}
+		op.tcpOutboundBufferLimit = limit
 	}}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -53,6 +53,10 @@ func TestTNETOptions(t *testing.T) {
 	WithSafeWrite(true).f(opts)
 	assert.True(t, opts.safeWrite)
 
+	WithTCPOutboundBufferLimit(1024).f(opts)
+	assert.Equal(t, 1024, opts.tcpOutboundBufferLimit)
+	WithTCPOutboundBufferLimit(1024).f(nil)
+
 	WithExactUDPBufferSizeEnabled(true).f(opts)
 	assert.True(t, opts.exactUDPBufferSizeEnabled)
 }

--- a/outbound.go
+++ b/outbound.go
@@ -1,0 +1,11 @@
+package tnet
+
+// OutboundBuffered returns the current outbound buffered bytes for conn.
+// It returns 0 if conn is nil or is not backed by tnet TCP.
+func OutboundBuffered(conn Conn) int {
+	tc, ok := conn.(*tcpconn)
+	if !ok || tc == nil {
+		return 0
+	}
+	return tc.outBuffer.LenRead()
+}

--- a/tcpconn.go
+++ b/tcpconn.go
@@ -48,6 +48,8 @@ var (
 	DefaultCleanUpThrottle = 10000
 	// ErrConnClosed connection is closed.
 	ErrConnClosed = netError{error: errors.New("conn is closed")}
+	// ErrOutboundBufferLimitExceeded means outbound buffered bytes exceeded the configured limit.
+	ErrOutboundBufferLimitExceeded = netError{error: errors.New("outbound buffer limit exceeded")}
 	// EAGAIN represents error of not enough data.
 	EAGAIN = netError{error: errors.New("no enough data, try it again")}
 )
@@ -73,12 +75,13 @@ type tcpconn struct {
 	nfd            netFD
 
 	closer
-	postpone    autopostpone.PostponeWrite
-	waitReadLen atomic.Int32
-	reading     locker.Locker
-	writing     locker.Locker
-	nonblocking bool
-	safeWrite   bool
+	postpone            autopostpone.PostponeWrite
+	waitReadLen         atomic.Int32
+	reading             locker.Locker
+	writing             locker.Locker
+	nonblocking         bool
+	safeWrite           bool
+	outboundBufferLimit int
 }
 
 // MassiveConnections denotes whether this is under heavy connections' scenario.
@@ -271,8 +274,13 @@ func (tc *tcpconn) Writev(p ...[]byte) (int, error) {
 	if !tc.beginJobSafely(apiWrite) {
 		return 0, ErrConnClosed
 	}
-	n := tc.outBuffer.Writev(tc.safeWrite, p...)
-	var err error
+	n, err := tc.writeToOutboundBuffer(p...)
+	if err != nil {
+		tc.endJobSafely(apiWrite)
+		metrics.Add(metrics.TCPOutboundBufferLimitExceeded, 1)
+		tc.Close()
+		return n, err
+	}
 	if tc.postpone.Enabled() {
 		err = tc.notify()
 	} else {
@@ -284,6 +292,20 @@ func (tc *tcpconn) Writev(p ...[]byte) (int, error) {
 		return n, err
 	}
 	tc.endJobSafely(apiWrite)
+	return n, nil
+}
+
+func (tc *tcpconn) writeToOutboundBuffer(p ...[]byte) (int, error) {
+	if tc == nil {
+		return 0, ErrConnClosed
+	}
+	if tc.outboundBufferLimit <= 0 {
+		return tc.outBuffer.Writev(tc.safeWrite, p...), nil
+	}
+	n, err := tc.outBuffer.WritevLimited(tc.safeWrite, tc.outboundBufferLimit, p...)
+	if err != nil {
+		return n, ErrOutboundBufferLimitExceeded
+	}
 	return n, nil
 }
 

--- a/tcpconn_outbound_test.go
+++ b/tcpconn_outbound_test.go
@@ -1,0 +1,43 @@
+package tnet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/tnet/metrics"
+)
+
+type nopSockCloser struct{}
+
+func (nopSockCloser) Close() error {
+	return nil
+}
+
+func TestTCPConnWritevOutboundBufferLimitExceeded(t *testing.T) {
+	tc := &tcpconn{
+		readTrigger:         make(chan struct{}),
+		outboundBufferLimit: 5,
+		nfd: netFD{
+			sock: nopSockCloser{},
+		},
+	}
+	tc.inBuffer.Initialize()
+	tc.outBuffer.Initialize()
+	tc.outBuffer.Writev(false, []byte("abcde"))
+	require.Equal(t, 5, OutboundBuffered(tc))
+
+	before := metrics.Get(metrics.TCPOutboundBufferLimitExceeded)
+	n, err := tc.Writev([]byte("f"))
+	require.True(t, errors.Is(err, ErrOutboundBufferLimitExceeded))
+	require.Zero(t, n)
+	require.False(t, tc.IsActive())
+	require.Equal(t, before+1, metrics.Get(metrics.TCPOutboundBufferLimitExceeded))
+}
+
+func TestTCPConnWriteToOutboundBufferNil(t *testing.T) {
+	var tc *tcpconn
+	n, err := tc.writeToOutboundBuffer([]byte("a"))
+	require.True(t, errors.Is(err, ErrConnClosed))
+	require.Zero(t, n)
+}

--- a/tcplistener_test.go
+++ b/tcplistener_test.go
@@ -26,6 +26,11 @@ import (
 	"trpc.group/trpc-go/tnet/internal/netutil"
 )
 
+const (
+	listenerAcceptTimeout  = time.Second
+	listenerAcceptInterval = 10 * time.Millisecond
+)
+
 func TestListen(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -95,7 +100,13 @@ func TestListenerAccept(t *testing.T) {
 			require.Nil(t, err)
 			defer client.Close()
 
-			conn, err := ln.Accept()
+			var conn net.Conn
+			require.Eventually(t, func() bool {
+				conn, err = ln.Accept()
+				return err == nil && conn != nil
+			}, listenerAcceptTimeout, listenerAcceptInterval, "accept connection failed: %v", err)
+			require.NotNil(t, conn)
+			defer conn.Close()
 			c := conn.(*tcpconn)
 			t.Logf("conn size: %v\n", unsafe.Sizeof(*c))
 			t.Logf("c.writevData.IsNil(): %v\n", c.writevData.IsNil())

--- a/tcpservice.go
+++ b/tcpservice.go
@@ -150,6 +150,7 @@ func tcpServiceOnRead(data interface{}, _ *iovec.IOData) error {
 		if err := tconn.SetReadIdleTimeout(s.opts.tcpReadIdleTimeout); err != nil {
 			return fmt.Errorf("tnet connection set read idle timeout error: %w", err)
 		}
+		tconn.outboundBufferLimit = s.opts.tcpOutboundBufferLimit
 		tconn.SetNonBlocking(s.opts.nonblocking)
 		tconn.SetSafeWrite(s.opts.safeWrite)
 		if s.opts.onTCPClosed != nil {

--- a/tls/conn.go
+++ b/tls/conn.go
@@ -37,6 +37,16 @@ func (c *conn) GetMetaData() interface{} {
 	return c.metaData
 }
 
+// OutboundBuffered returns the current outbound buffered bytes for c.
+// It returns 0 if c is nil or is not backed by tnet TCP.
+func OutboundBuffered(c Conn) int {
+	tc, ok := c.(*conn)
+	if !ok || tc == nil {
+		return 0
+	}
+	return tnet.OutboundBuffered(tc.raw)
+}
+
 // SetIdleTimeout sets connection level idle timeout.
 func (c *conn) SetIdleTimeout(d time.Duration) error {
 	return c.raw.SetIdleTimeout(d)

--- a/tls/options.go
+++ b/tls/options.go
@@ -21,12 +21,13 @@ import (
 const defaultDialTimeout = 10 * time.Second
 
 type serverOptions struct {
-	cfg         *tls.Config
-	keepAlive   time.Duration
-	idleTimeout time.Duration
-	flushWrite  bool
-	onOpened    OnOpened
-	onClosed    OnClosed
+	cfg                 *tls.Config
+	keepAlive           time.Duration
+	idleTimeout         time.Duration
+	flushWrite          bool
+	outboundBufferLimit int
+	onOpened            OnOpened
+	onClosed            OnClosed
 }
 
 // OnOpened fires when the tcp connection is established.
@@ -65,6 +66,17 @@ func WithServerIdleTimeout(idleTimeout time.Duration) ServerOption {
 func WithServerFlushWrite(flushWrite bool) ServerOption {
 	return func(o *serverOptions) {
 		o.flushWrite = flushWrite
+	}
+}
+
+// WithServerOutboundBufferLimit sets the max outbound buffered bytes for each server connection.
+// If limit is less than or equal to 0, the limit check is disabled.
+func WithServerOutboundBufferLimit(limit int) ServerOption {
+	return func(o *serverOptions) {
+		if o == nil {
+			return
+		}
+		o.outboundBufferLimit = limit
 	}
 }
 

--- a/tls/options_test.go
+++ b/tls/options_test.go
@@ -1,0 +1,14 @@
+package tls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerOutboundBufferLimitOption(t *testing.T) {
+	opts := &serverOptions{}
+	WithServerOutboundBufferLimit(1024)(opts)
+	assert.Equal(t, 1024, opts.outboundBufferLimit)
+	WithServerOutboundBufferLimit(1024)(nil)
+}

--- a/tls/server.go
+++ b/tls/server.go
@@ -33,6 +33,7 @@ func NewService(ln net.Listener, handler Handler, opts ...ServerOption) (tnet.Se
 	tnetOpts := []tnet.Option{
 		tnet.WithTCPKeepAlive(options.keepAlive),
 		tnet.WithTCPIdleTimeout(options.idleTimeout),
+		tnet.WithTCPOutboundBufferLimit(options.outboundBufferLimit),
 		// After sending the data, tls needs to reuse the underlying
 		// bytes slice, so SafeWrite must be enabled to ensure that
 		// a copy is made when the data is written.


### PR DESCRIPTION
## Summary
- add an opt-in TCP outbound buffer limit to back-pressure slow readers
- expose `OutboundBuffered` helpers for tnet, TLS, and websocket connections
- report outbound buffer limit exceed events in metrics
- wire server options through tnet, TLS, and websocket services

## Compatibility
- the limit is disabled by default when unset or non-positive
- existing write behavior is unchanged unless the new option is configured
- public module paths are preserved

## Validation
- `go test . ./internal/buffer ./metrics ./tls -run 'Test(TCPConnWritevOutboundBufferLimitExceeded|TCPConnWriteToOutboundBufferNil|Buffer_WritevLimited|Metric|ServerOutboundBufferLimit|OutboundBuffered)' -count=1`
- `go test . -run 'TestServerOutboundBufferLimit' -count=1` in `extensions/websocket`
- `go test $(go list ./... | grep -v /internal/reuseport) -count=1`