### PR TITLE
ci: pin pull request check tools

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -37,14 +37,14 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest 
+          version: latest
           only-new-issues: true
   typos:
     name: typos
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: typos 
+    - name: typos
       uses: crate-ci/typos@master
   go-apidiff:
     if: github.event_name == 'pull_request'
@@ -52,8 +52,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
         go-version: 1.19
     - uses: joelanford/go-apidiff@main
+      with:
+        version: v0.7.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[default.extend-words]
+hel = "hel"
+lok = "lok"
+UNKOWN = "UNKOWN"
+Writeable = "Writeable"


### PR DESCRIPTION
## Summary
- pin go-apidiff to the latest version compatible with the workflow Go version
- add a typos allowlist for existing identifiers and compatibility-sensitive strings
- clean up trailing spaces in the pull request workflow

## Tests
- go install github.com/joelanford/go-apidiff@v0.7.0
- git diff --check