### PR TITLE
websocket: respect wss dial timeout

### DIFF
--- a/extensions/websocket/client.go
+++ b/extensions/websocket/client.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	neturl "net/url"
 	"strings"
+	"time"
 
 	"github.com/gobwas/ws"
 	"trpc.group/trpc-go/tnet"
@@ -38,9 +39,13 @@ func Dial(url string, opts ...ClientOption) (Conn, error) {
 	for _, opt := range opts {
 		opt(&options)
 	}
+	start := time.Now()
 	c, err := dial(u, &options)
 	if err != nil {
 		return nil, err
+	}
+	if options.timeout > 0 {
+		_ = c.SetDeadline(start.Add(options.timeout))
 	}
 	dialer := ws.Dialer{
 		Protocols:     options.subprotocols,
@@ -50,7 +55,11 @@ func Dial(url string, opts ...ClientOption) (Conn, error) {
 	}
 	br, handshake, err := dialer.Upgrade(c, u)
 	if err != nil {
+		c.Close()
 		return nil, err
+	}
+	if options.timeout > 0 {
+		_ = c.SetDeadline(time.Time{})
 	}
 	var source io.Reader
 	if br != nil {
@@ -59,6 +68,7 @@ func Dial(url string, opts ...ClientOption) (Conn, error) {
 			prefix := make([]byte, n)
 			if _, err := io.ReadFull(br, prefix); err != nil {
 				ws.PutReader(br)
+				c.Close()
 				return nil, err
 			}
 			source = io.MultiReader(bytes.NewReader(prefix), c)
@@ -99,7 +109,10 @@ func dial(u *neturl.URL, options *clientOptions) (rawConnection, error) {
 		if options.tlsConfig.ServerName == "" {
 			options.tlsConfig.ServerName = hostname
 		}
-		c, err := tls.Dial("tcp", addr, tls.WithClientTLSConfig(options.tlsConfig))
+		c, err := tls.Dial("tcp", addr,
+			tls.WithClientTLSConfig(options.tlsConfig),
+			tls.WithTimeout(options.timeout),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/extensions/websocket/client_test.go
+++ b/extensions/websocket/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha1"
+	stdtls "crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -187,6 +188,73 @@ func TestClientHandshakeHeaderAndBufferedBytes(t *testing.T) {
 	obs := <-obsCh
 	require.NoError(t, obs.err)
 	require.Equal(t, "abc", obs.xToken)
+}
+
+func TestWSSDialUsesConfiguredTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	serverDone := make(chan struct{})
+	t.Cleanup(func() { close(serverDone) })
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		<-serverDone
+	}()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := websocket.Dial("wss://"+ln.Addr().String()+"/",
+			websocket.WithTimeout(50*time.Millisecond),
+			websocket.WithClientTLSConfig(&stdtls.Config{InsecureSkipVerify: true}),
+		)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.Less(t, time.Since(start), time.Second)
+	case <-time.After(time.Second):
+		t.Fatal("wss dial did not respect timeout")
+	}
+}
+
+func TestDialUpgradeUsesConfiguredTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	serverDone := make(chan struct{})
+	t.Cleanup(func() { close(serverDone) })
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		<-serverDone
+	}()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := websocket.Dial("ws://"+ln.Addr().String()+"/", websocket.WithTimeout(50*time.Millisecond))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.Less(t, time.Since(start), time.Second)
+	case <-time.After(time.Second):
+		t.Fatal("websocket upgrade did not respect timeout")
+	}
 }
 
 type statusErrorObservation struct {

--- a/tcpconn_outbound_test.go
+++ b/tcpconn_outbound_test.go
@@ -17,6 +17,7 @@ func (nopSockCloser) Close() error {
 func TestTCPConnWritevOutboundBufferLimitExceeded(t *testing.T) {
 	tc := &tcpconn{
 		readTrigger:         make(chan struct{}),
+		closedFinished:      make(chan struct{}),
 		outboundBufferLimit: 5,
 		nfd: netFD{
 			sock: nopSockCloser{},


### PR DESCRIPTION
## Summary

- Pass the configured websocket client timeout into WSS TLS dialing.
- Apply the same timeout to the HTTP Upgrade handshake and clear the deadline after a successful upgrade.
- Close the raw connection on failed client upgrade paths.
- Add regression tests for WSS TLS handshake timeout and websocket upgrade timeout.
- Initialize the outbound-buffer test TCP fixture so root package tests do not panic when closing it.

## Compatibility

This is a bug fix for existing `WithTimeout` behavior. It does not add or remove public APIs.

## Validation

- cd extensions/websocket && go test ./... -count=1
- go test . -run TestTCPConnWritevOutboundBufferLimitExceeded -count=1
- go test . -count=1
