### PR TITLE
ci: fix push checks

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 5
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 85%
+        threshold: 0%

--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -28,6 +28,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   golangci:
     name: lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4

--- a/internal/reuseport/reuseport.go
+++ b/internal/reuseport/reuseport.go
@@ -168,7 +168,7 @@ func createPacketConn(fd int, sockaddr syscall.Sockaddr, fdName string) (net.Pac
 	return l, err
 }
 
-var reusePort = 0x0F
+var reusePort = soReusePort
 
 func setPacketConnSockOpt(fd int, sockaddr syscall.Sockaddr) error {
 	if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {

--- a/internal/reuseport/reuseport_darwin.go
+++ b/internal/reuseport/reuseport_darwin.go
@@ -1,0 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package reuseport
+
+const soReusePort = 0x0200

--- a/internal/reuseport/reuseport_linux.go
+++ b/internal/reuseport/reuseport_linux.go
@@ -1,0 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package reuseport
+
+const soReusePort = 0x0F

--- a/internal/reuseport/reuseport_other.go
+++ b/internal/reuseport/reuseport_other.go
@@ -1,0 +1,18 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+//go:build !darwin && !linux
+
+package reuseport
+
+const soReusePort = 0x0F

--- a/internal/reuseport/reuseport_test.go
+++ b/internal/reuseport/reuseport_test.go
@@ -17,19 +17,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewReusablePortPacketConn(t *testing.T) {
 	listenerOne, err := NewReusablePortPacketConn("udp4", "localhost:10082")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer listenerOne.Close()
 
 	listenerTwo, err := NewReusablePortPacketConn("udp", "127.0.0.1:10082")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer listenerTwo.Close()
 
 	listenerThree, err := NewReusablePortPacketConn("udp6", ":10082")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer listenerThree.Close()
 
 }


### PR DESCRIPTION
## Summary

- Run golangci-lint only for pull requests, where only-new-issues has the required diff context.
- Keep golangci-lint on latest while avoiding push-event failures from repository-wide historical lint issues.
- Add Codecov configuration that keeps patch coverage gated at 85% while making project coverage informational.
- Use platform-specific SO_REUSEPORT values and stop reuseport tests from panicking after setup failures.

## Validation

- go test ./internal/reuseport -count=1 -v
- go test ./... -count=1
- cd extensions/websocket && go test ./... -count=1
- cd examples && go test ./... -count=1
- go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --new-from-rev=upstream/main
- GOOS=linux GOARCH=amd64 go test -c ./internal/reuseport