### PR TITLE
tnet: keep udp poller active after send errors

### DIFF
--- a/netfd_linux.go
+++ b/netfd_linux.go
@@ -118,22 +118,37 @@ func (nfd *netFD) sendMMsg(b *buffer.Buffer) error {
 	}
 
 	l := b.PeekBlocks(bufs)
+	if l == 0 {
+		return nil
+	}
 	mmsgs, bufs = mmsgs[:l], bufs[:l]
 
 	buildMMsgs(mmsgs, bufs)
 
 	n, err := nfd.syscallMMsg(unix.SYS_SENDMMSG, mmsgs)
 	metrics.Add(metrics.UDPSendMMsgCalls, 1)
+	if n > 0 {
+		metrics.Add(metrics.UDPSendMMsgPackets, uint64(n))
+		if skipErr := b.SkipBlocks(n); skipErr != nil {
+			return skipErr
+		}
+		b.Release()
+	}
 	if err != nil {
 		metrics.Add(metrics.UDPSendMMsgFails, 1)
-		return err
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return err
+		}
+		// UDP send errors are scoped to the current datagram. Returning the
+		// error would make the poller detach the shared UDP listener fd.
+		if b.LenRead() != 0 {
+			if skipErr := b.SkipBlocks(1); skipErr != nil {
+				return skipErr
+			}
+			b.Release()
+		}
 	}
-	metrics.Add(metrics.UDPSendMMsgPackets, uint64(n))
-	if err := b.SkipBlocks(n); err != nil {
-		return err
-	}
-	b.Release()
-	return err
+	return nil
 }
 
 func buildMMsgs(mmsgs []systype.MMsghdr, bufs [][]byte) error {

--- a/udpconn_linux_test.go
+++ b/udpconn_linux_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+// +build linux
+
+package tnet
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/tnet/internal/poller"
+)
+
+func TestUDPConnWriteToDropsFailedPacketAndContinues(t *testing.T) {
+	raw, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := newUDPConn(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.postpone.Set(true)
+	if err := conn.SetOnRequest(func(PacketConn) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.schedule(); err != nil {
+		t.Fatal(err)
+	}
+
+	receiver, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer receiver.Close()
+
+	goodAddr := receiver.LocalAddr()
+	badAddr := &net.UDPAddr{IP: net.ParseIP("::1"), Port: 25000}
+	first := []byte("first")
+	second := []byte("second")
+
+	if n, err := conn.WriteTo(first, goodAddr); err != nil || n != len(first) {
+		t.Fatalf("WriteTo(first) = %d, %v; want %d, nil", n, err, len(first))
+	}
+	if n, err := conn.WriteTo([]byte("bad"), badAddr); err != nil || n != len("bad") {
+		t.Fatalf("WriteTo(bad) = %d, %v; want %d, nil", n, err, len("bad"))
+	}
+	if n, err := conn.WriteTo(second, goodAddr); err != nil || n != len(second) {
+		t.Fatalf("WriteTo(second) = %d, %v; want %d, nil", n, err, len(second))
+	}
+
+	got := readUDPPayloads(t, receiver, 2)
+	if string(got[0]) != string(first) || string(got[1]) != string(second) {
+		t.Fatalf("received payloads = %q, want [%q %q]", got, first, second)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if conn.outBuffer.LenRead() == 0 && !conn.writing.IsLocked() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if conn.outBuffer.LenRead() != 0 {
+		t.Fatalf("outBuffer length = %d, want 0", conn.outBuffer.LenRead())
+	}
+	if conn.writing.IsLocked() {
+		t.Fatal("writing lock is still held")
+	}
+	if err := conn.nfd.Control(poller.ModReadable); err != nil {
+		t.Fatalf("udp fd was detached from poller: %v", err)
+	}
+}
+
+func readUDPPayloads(t *testing.T, receiver net.PacketConn, n int) [][]byte {
+	t.Helper()
+
+	got := make([][]byte, 0, n)
+	buf := make([]byte, defaultUDPBufferSize)
+	deadline := time.Now().Add(2 * time.Second)
+	for len(got) < n {
+		if err := receiver.SetReadDeadline(deadline); err != nil {
+			t.Fatal(err)
+		}
+		read, _, err := receiver.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("read payload %d/%d: %v", len(got)+1, n, err)
+		}
+		payload := make([]byte, read)
+		copy(payload, buf[:read])
+		got = append(got, payload)
+	}
+	return got
+}


### PR DESCRIPTION
## Summary

- keep UDP listener fds registered with the poller when a queued datagram fails with a non-retryable sendmmsg error
- drop the failed UDP datagram and continue flushing later queued datagrams
- add a Linux regression test covering a failed queued UDP packet followed by a valid packet

## Root Cause

UDP async writes can enqueue packets in `outBuffer` and rely on poller write events to flush them. If `sendmmsg` returns a non-EAGAIN error for the queued head packet, `udpOnWrite` previously returned that error to the poller. The poller then detached the shared UDP listener fd, while the UDP connection object stayed active with `writing` held and queued packets left in `outBuffer`.

## Validation

- `go test -run TestUDPConnWriteToDropsFailedPacketAndContinues -v -count=1`
- `go test -run 'TestUDPConnWriteToDropsFailedPacketAndContinues|Test_netFD' -v -count=1`
- `go test ./...`

Fixes #26
