### PR TITLE
tnet: cover udp send error branches

### DIFF
--- a/udpconn_linux_test.go
+++ b/udpconn_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"trpc.group/trpc-go/tnet/internal/buffer"
 	"trpc.group/trpc-go/tnet/internal/poller"
 )
 
@@ -70,6 +71,105 @@ func TestUDPConnWriteToDropsFailedPacketAndContinues(t *testing.T) {
 	}
 	if err := conn.nfd.Control(poller.ModReadable); err != nil {
 		t.Fatalf("udp fd was detached from poller: %v", err)
+	}
+}
+
+func TestNetFDSendPacketsWithEmptyBuffer(t *testing.T) {
+	raw, err := rawListenUDP("udp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	nfd, err := rawToNetFD(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := buffer.New()
+	if err := nfd.SendPackets(b); err != nil {
+		t.Fatalf("SendPackets() = %v, want nil", err)
+	}
+	if b.LenRead() != 0 {
+		t.Fatalf("buffer length = %d, want 0", b.LenRead())
+	}
+}
+
+func TestNetFDSendPacketsDropsFailedPacket(t *testing.T) {
+	raw, err := rawListenUDP("udp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	nfd, err := rawToNetFD(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := buffer.New()
+	block, err := parcel([]byte("bad"), &net.UDPAddr{IP: net.ParseIP("::1"), Port: 25000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Write(false, block)
+
+	if err := nfd.SendPackets(b); err != nil {
+		t.Fatalf("SendPackets() = %v, want nil", err)
+	}
+	if b.LenRead() != 0 {
+		t.Fatalf("buffer length = %d, want 0", b.LenRead())
+	}
+}
+
+func TestNetFDSendPacketsContinuesAfterFailedPacket(t *testing.T) {
+	raw, err := rawListenUDP("udp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	nfd, err := rawToNetFD(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receiver, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer receiver.Close()
+
+	b := buffer.New()
+	firstBlock, err := parcel([]byte("first"), receiver.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	badBlock, err := parcel([]byte("bad"), &net.UDPAddr{IP: net.ParseIP("::1"), Port: 25000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBlock, err := parcel([]byte("second"), receiver.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Write(false, firstBlock)
+	b.Write(false, badBlock)
+	b.Write(false, secondBlock)
+
+	if err := nfd.SendPackets(b); err != nil {
+		t.Fatalf("SendPackets(first) = %v, want nil", err)
+	}
+	if err := nfd.SendPackets(b); err != nil {
+		t.Fatalf("SendPackets(bad) = %v, want nil", err)
+	}
+	if err := nfd.SendPackets(b); err != nil {
+		t.Fatalf("SendPackets(second) = %v, want nil", err)
+	}
+
+	got := readUDPPayloads(t, receiver, 2)
+	if string(got[0]) != "first" || string(got[1]) != "second" {
+		t.Fatalf("received payloads = %q, want [first second]", got)
+	}
+	if b.LenRead() != 0 {
+		t.Fatalf("buffer length = %d, want 0", b.LenRead())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add direct Linux tests for UDP SendPackets with an empty outbound buffer
- cover dropping a failed queued UDP datagram without returning an error
- cover continuing to send later queued UDP datagrams after a failed packet

## CI Alignment

I compared the current tnet workflow with trpc-go. The main red status after #34 is Codecov patch coverage, not a GitHub Actions failure. The tnet push workflow is already green after #33 restricted lint and apidiff to pull requests, so this PR keeps workflow configuration unchanged and focuses on the missing UDP send coverage.

## Validation

- go test -run 'TestUDPConnWriteToDropsFailedPacketAndContinues|TestNetFDSendPackets' -v -count=1
- go test -coverprofile=/tmp/tnet_root.cover .
- go test ./...